### PR TITLE
Add login_hint feature and bump version to 0.2.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 This is an updated version of [TokenTactics](https://github.com/rvrsh3ll/TokenTactics) originally written by Stephan Borosh [@rvrsh3ll](https://github.com/rvrsh3ll) & Bobby Cooke [@0xBoku](https://github.com/boku7).
 
+### 0.2.14 (2025-09-11)
+
+* Add parameter `-Username` to prefill the **login_hint** parameter in cmdlet `Get-AzureAuthorizationCode`
+
 ### 0.2.13 (2025-07-29)
 
 * Fix for Custom User Agent parameter

--- a/TokenTactics.psd1
+++ b/TokenTactics.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'TokenTactics.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.2.13'
+    ModuleVersion     = '0.2.14'
     
     # ID used to uniquely identify this module
     GUID              = '6194f0f0-8b91-4c32-b1b1-bc46c9d7a95c'

--- a/modules/TokenHandler.ps1
+++ b/modules/TokenHandler.ps1
@@ -869,6 +869,8 @@ function Get-AzureAuthorizationCode {
         [Parameter(Mandatory = $False)]
         [string]$Resource,
         [Parameter(Mandatory = $False)]
+        [string]$Username,
+        [Parameter(Mandatory = $False)]
         [switch]$OpenInBrowser
     )
     if ( $UseV1Endpoint ) {
@@ -887,6 +889,9 @@ function Get-AzureAuthorizationCode {
         $CodeChallenge = Get-TTCodeChallenge -CodeVerifier $CodeVerifier
         $BaseUrl += "&code_challenge=$CodeChallenge"
         $BaseUrl += "&code_challenge_method=S256"
+    }
+    if ($Username) {
+        $BaseUrl += "&login_hint=$Username"
     }
 
     if ($Client -ne "Custom" -and -not ( [string]::IsNullOrWhiteSpace($Scope) )) {


### PR DESCRIPTION
Introduce a new parameter `-Username` to prefill the **login_hint** in the `Get-AzureAuthorizationCode` cmdlet and update the module version accordingly.