### PR TITLE
feat: Add support for alternative passkey JSON formats

### DIFF
--- a/modules/Invoke-EntraIDPasskeyLogin.ps1
+++ b/modules/Invoke-EntraIDPasskeyLogin.ps1
@@ -69,7 +69,7 @@ function Invoke-EntraIDPasskeyLogin {
     }
 
     # Determine FIDO Parameters from JSON (Critical for the HAR flow)
-    $rpId = $keyData.relyingParty ?? $RelyingParty
+    $rpId = $keyData.relyingParty ?? $keyData.rpId ?? $RelyingParty
     $origin = $keyData.url ?? "https://$($rpId)"
     # Make sure origin is just scheme + host
     $origin = [uri]"$origin" | Select-Object -ExpandProperty Host
@@ -85,6 +85,19 @@ function Invoke-EntraIDPasskeyLogin {
         Write-Error "CredentialId not found in JSON or arguments."
         exit 1
     }
+    
+    # Convert UUID format to base64url if necessary (contains dashes)
+    if ($credentialId -match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') {
+        Write-Verbose "Converting UUID format credential ID to base64url"
+        # Parse as hex string, not as GUID (to preserve byte order)
+        $hexString = $credentialId.Replace('-', '')
+        $rawBytes = [byte[]]::new($hexString.Length / 2)
+        for ($i = 0; $i -lt $hexString.Length; $i += 2) {
+            $rawBytes[$i / 2] = [Convert]::ToByte($hexString.Substring($i, 2), 16)
+        }
+        $base64 = [Convert]::ToBase64String($rawBytes)
+        $credentialId = $base64.Replace('+', '-').Replace('/', '_').TrimEnd('=')
+    }
 
     Write-Host "$([char]0x2714) User:       $targetUser" -ForegroundColor Gray
     Write-Host "$([char]0x2714) RP ID:      $rpId" -ForegroundColor Gray
@@ -94,7 +107,7 @@ function Invoke-EntraIDPasskeyLogin {
 
     # Private Key and Sign Count
     [int]$SignCount = $keyData.signCount ?? 0
-    $PrivateKeyPem = $keyData.privateKey ?? $PrivateKey
+    $PrivateKeyPem = $keyData.privateKey ?? $keyData.keyValue ?? $PrivateKey
     $PrivateKeyPem = ConvertTo-PEMPrivateKey -PrivateKey $PrivateKeyPem
     if (-not $PrivateKeyPem) {
         Write-Error "Private key not found in JSON or arguments."


### PR DESCRIPTION
## Summary
This PR adds support for alternative passkey JSON file formats, allowing Invoke-EntraIDPasskeyLogin to work with passkey exports from different tools.

## Changes
- Add support for \keyValue\ field in addition to \privateKey\
- Add support for \pId\ field in addition to \elyingParty\
- Add UUID-format credential ID conversion to base64url
- Fix byte order preservation when converting UUID to base64url (using raw hex parsing instead of GUID parser)

## Problem Solved
Previously, the function only worked with a specific passkey JSON format. Some passkey export tools use different field names (\keyValue\ vs \privateKey\, \pId\ vs \elyingParty\) and formats (UUID strings with dashes for credential IDs instead of base64url).

This caused authentication failures with error:
\\\
Cannot bind argument to parameter 'PrivateKey' because it is an empty string.
\\\

## Testing
Tested successfully with both passkey formats:
1. Original format with \privateKey\ and base64url \credentialId\
2. Alternative format with \keyValue\ and UUID-format \credentialId\

Both formats now authenticate successfully against Microsoft Entra ID.