### PR TITLE
fix: Restore base64 padding in ConvertTo-PEMPrivateKey for base64url-encoded keys

### DIFF
--- a/modules/ConvertTo-PEMPrivateKey.ps1
+++ b/modules/ConvertTo-PEMPrivateKey.ps1
@@ -29,8 +29,10 @@ function ConvertTo-PEMPrivateKey {
         # Remove any whitespace
         $cleanKey = $PrivateKey.Trim() -replace "`r|`n|\s", ""
 
-        # Replace invalid characters (if any)
+        # Convert base64url to standard base64 (replace URL-safe chars and restore padding)
         $cleanKey = $cleanKey -replace "-", "+" -replace "_", "/"
+        $padLength = (4 - ($cleanKey.Length % 4)) % 4
+        $cleanKey = $cleanKey + ('=' * $padLength)
 
         # Wrap at 64 characters
         $wrappedKey = ""

--- a/modules/Invoke-EntraIDPasskeyLogin.ps1
+++ b/modules/Invoke-EntraIDPasskeyLogin.ps1
@@ -69,7 +69,7 @@ function Invoke-EntraIDPasskeyLogin {
     }
 
     # Determine FIDO Parameters from JSON (Critical for the HAR flow)
-    $rpId = $keyData.relyingParty ?? $RelyingParty
+    $rpId = $keyData.relyingParty ?? $keyData.rpId ?? $RelyingParty
     $origin = $keyData.url ?? "https://$($rpId)"
     # Make sure origin is just scheme + host
     $origin = [uri]"$origin" | Select-Object -ExpandProperty Host
@@ -85,6 +85,19 @@ function Invoke-EntraIDPasskeyLogin {
         Write-Error "CredentialId not found in JSON or arguments."
         exit 1
     }
+    
+    # Convert UUID format to base64url if necessary (contains dashes)
+    if ($credentialId -match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$') {
+        Write-Verbose "Converting UUID format credential ID to base64url"
+        # Parse as hex string, not as GUID (to preserve byte order)
+        $hexString = $credentialId.Replace('-', '')
+        $rawBytes = [byte[]]::new($hexString.Length / 2)
+        for ($i = 0; $i -lt $hexString.Length; $i += 2) {
+            $rawBytes[$i / 2] = [Convert]::ToByte($hexString.Substring($i, 2), 16)
+        }
+        $base64 = [Convert]::ToBase64String($rawBytes)
+        $credentialId = $base64.Replace('+', '-').Replace('/', '_').TrimEnd('=')
+    }
 
     Write-Host "$([char]0x2714) User:       $targetUser" -ForegroundColor Gray
     Write-Host "$([char]0x2714) RP ID:      $rpId" -ForegroundColor Gray
@@ -94,7 +107,7 @@ function Invoke-EntraIDPasskeyLogin {
 
     # Private Key and Sign Count
     [int]$SignCount = $keyData.signCount ?? 0
-    $PrivateKeyPem = $keyData.privateKey ?? $PrivateKey
+    $PrivateKeyPem = $keyData.privateKey ?? $keyData.keyValue ?? $PrivateKey
     $PrivateKeyPem = ConvertTo-PEMPrivateKey -PrivateKey $PrivateKeyPem
     if (-not $PrivateKeyPem) {
         Write-Error "Private key not found in JSON or arguments."


### PR DESCRIPTION
## Problem

`ConvertTo-PEMPrivateKey` already converts base64url characters back to standard base64 (`-` → `+`, `_` → `/`), but does **not** restore the `=` padding that base64url encoding strips. If a user provides a base64url-encoded private key (e.g. from a passkey export tool), the resulting PEM will have an improperly encoded body and key import will fail.

## Fix

After converting the URL-safe characters, restore any missing base64 padding before wrapping the key into PEM format.

## Changes

- `modules/ConvertTo-PEMPrivateKey.ps1`: Added padding restoration after base64url → base64 character conversion.