### PR TITLE
Add Pester 5 tests for all user-facing functions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "PowerShell",
-  "image": "mcr.microsoft.com/powershell:latest",
+  "image": "mcr.microsoft.com/powershell:7.6-debian-12",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {
       "installZsh": "true",
@@ -9,9 +9,10 @@
       "nonFreePackages": "true"
     },
     "ghcr.io/natescherer/devcontainers-custom-features/powershell-resources:1": {
-      "resources": "Pester,PSScriptAnalyzer"
+      "resources": "PSScriptAnalyzer"
     }
   },
+  "postCreateCommand": "pwsh -NoProfile -Command \"Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force\"",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pester:
+    name: PowerShell 7 (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          if (-not (Get-Module -ListAvailable Pester | Where-Object Version -EQ '5.7.1')) {
+              Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force
+          }
+
+      - name: Run tests
+        shell: pwsh
+        run: ./tests/Invoke-Tests.ps1
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.os }}
+          path: |
+            coverage.xml
+            test-results.xml
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+coverage.xml
+test-results.xml

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ Get-Help Get-EntraIDToken
 Invoke-RefreshToSubstrateToken -Domain "myclient.org"
 ```
 
+## Testing
+
+The test suite requires PowerShell 7 and Pester 5.7.1. It uses mocked HTTP responses and does not require Entra ID credentials or network access.
+
+```powershell
+Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser
+pwsh ./tests/Invoke-Tests.ps1
+```
+
+The same suite runs on Linux, macOS, and Windows for every pull request.
+
 ### Get refresh token using Device Code flow
 
 ```powershell
@@ -176,75 +187,9 @@ Set-AADIntTeamsStatusMessage -Message "My cool status message" -AccessToken $MST
 
 ```powershell
 Get-Command -Module TokenTactics
-
-CommandType     Name                                               Version    Source
------------     ----                                               -------    ------
-Alias           Forge-UserAgent                                    0.2.20     TokenTactics
-Alias           Get-AzureAuthorizationCode                         0.2.20     TokenTactics
-Alias           Get-AzureToken                                     0.2.20     TokenTactics
-Alias           Get-AzureTokenFromAuthorizationCode                0.2.20     TokenTactics
-Alias           Get-AzureTokenFromCookie                           0.2.20     TokenTactics
-Alias           Get-AzureTokenFromESTSCookie                       0.2.20     TokenTactics
-Alias           Get-AzureTokenFromRefreshTokenCredentialCookie     0.2.20     TokenTactics
-Alias           Parse-JWTtoken                                     0.2.20     TokenTactics
-Alias           RefreshTo-AzureCoreManagementToken                 0.2.20     TokenTactics
-Alias           RefreshTo-AzureKeyVaultToken                       0.2.20     TokenTactics
-Alias           RefreshTo-AzureManagementToken                     0.2.20     TokenTactics
-Alias           RefreshTo-AzureStorageToken                        0.2.20     TokenTactics
-Alias           RefreshTo-DeviceRegistrationToken                  0.2.20     TokenTactics
-Alias           RefreshTo-DODMSGraphToken                          0.2.20     TokenTactics
-Alias           RefreshTo-GraphToken                               0.2.20     TokenTactics
-Alias           RefreshTo-MAMToken                                 0.2.20     TokenTactics
-Alias           RefreshTo-MSGraphToken                             0.2.20     TokenTactics
-Alias           RefreshTo-MSManageToken                            0.2.20     TokenTactics
-Alias           RefreshTo-MSTeamsToken                             0.2.20     TokenTactics
-Alias           RefreshTo-OfficeAppsToken                          0.2.20     TokenTactics
-Alias           RefreshTo-OfficeManagementToken                    0.2.20     TokenTactics
-Alias           RefreshTo-OneDriveToken                            0.2.20     TokenTactics
-Alias           RefreshTo-OutlookToken                             0.2.20     TokenTactics
-Alias           RefreshTo-SharePointToken                          0.2.20     TokenTactics
-Alias           RefreshTo-SubstrateToken                           0.2.20     TokenTactics
-Alias           RefreshTo-YammerToken                              0.2.20     TokenTactics
-Function        Clear-Token                                        0.2.20     TokenTactics
-Function        ConvertFrom-JWTtoken                               0.2.20     TokenTactics
-Function        ConvertTo-Base64Url                                0.2.20     TokenTactics
-Function        ConvertTo-PEMPrivateKey                            0.2.20     TokenTactics
-Function        ConvertTo-URLParameters                            0.2.20     TokenTactics
-Function        Get-EntraIDAuthorizationCode                       0.2.20     TokenTactics
-Function        Get-EntraIDToken                                   0.2.20     TokenTactics
-Function        Get-EntraIDTokenFromAuthorizationCode              0.2.20     TokenTactics
-Function        Get-EntraIDTokenFromCookie                         0.2.20     TokenTactics
-Function        Get-EntraIDTokenFromESTSCookie                     0.2.20     TokenTactics
-Function        Get-EntraIDTokenFromRefreshTokenCredentialCookie   0.2.20     TokenTactics
-Function        Get-EntraIDTokenFromSCCAUTHCookie                  0.2.22     TokenTactics
-Function        Get-ForgedUserAgent                                0.2.20     TokenTactics
-Function        Get-TenantID                                       0.2.20     TokenTactics
-Function        Get-TTCodeChallenge                                0.2.20     TokenTactics
-Function        Get-TTCodeVerifier                                 0.2.20     TokenTactics
-Function        Invoke-EntraErrorHandling                          0.2.20     TokenTactics
-Function        Invoke-EntraIDPasskeyLogin                         0.2.20     TokenTactics
-Function        Invoke-RefreshToAzureCoreManagementToken           0.2.20     TokenTactics
-Function        Invoke-RefreshToAzureKeyVaultToken                 0.2.20     TokenTactics
-Function        Invoke-RefreshToAzureManagementToken               0.2.20     TokenTactics
-Function        Invoke-RefreshToAzureStorageToken                  0.2.20     TokenTactics
-Function        Invoke-RefreshToDeviceRegistrationToken            0.2.20     TokenTactics
-Function        Invoke-RefreshToDODMSGraphToken                    0.2.20     TokenTactics
-Function        Invoke-RefreshToGraphToken                         0.2.20     TokenTactics
-Function        Invoke-RefreshToMAMToken                           0.2.20     TokenTactics
-Function        Invoke-RefreshToMSGraphToken                       0.2.20     TokenTactics
-Function        Invoke-RefreshToMSManageToken                      0.2.20     TokenTactics
-Function        Invoke-RefreshToMSTeamsToken                       0.2.20     TokenTactics
-Function        Invoke-RefreshToOfficeAppsToken                    0.2.20     TokenTactics
-Function        Invoke-RefreshToOfficeManagementToken              0.2.20     TokenTactics
-Function        Invoke-RefreshToOneDriveToken                      0.2.20     TokenTactics
-Function        Invoke-RefreshToOutlookToken                       0.2.20     TokenTactics
-Function        Invoke-RefreshToSharePointToken                    0.2.20     TokenTactics
-Function        Invoke-RefreshToSubstrateToken                     0.2.20     TokenTactics
-Function        Invoke-RefreshToToken                              0.2.20     TokenTactics
-Function        Invoke-RefreshToYammerToken                        0.2.20     TokenTactics
-Function        New-FidoAuthenticatorData                          0.2.20     TokenTactics
-Function        New-FidoSignature                                  0.2.20     TokenTactics
 ```
+
+Only supported user-facing commands are exported; parsing, PKCE, generic refresh, and FIDO cryptographic helpers remain private implementation details.
 
 ## Authors and contributors
 - [@rvrsh3ll](https://github.com/rvrsh3ll) Author of TokenTactics (original)
@@ -255,6 +200,13 @@ Function        New-FidoSignature                                  0.2.20     To
 TokenTactic's methods are highly influenced by the great research of Dr Nestori Syynimaa at https://o365blog.com/.
 
 ## Changelog
+
+### 0.3.0 (2026-07-13)
+
+* Add a pinned Pester 5 test runner, cross-platform GitHub Actions checks, test reports, and an enforced coverage baseline.
+* Add deterministic mocked coverage for device code, cookie, authorization code, SCCAUTH, refresh-token, and passkey flows.
+* Fix token cleanup, URL decoding, UTC JWT timestamps, PEM validation, Yammer scope, CAE cookie support, PurviewACC tenant headers, and passkey assertion construction.
+* Export only supported user-facing commands and compatibility aliases. Implementation helpers previously exposed by the wildcard export are now private; scripts should use the corresponding public commands instead.
 
 ### 0.2.22 (2026-04-03)
 

--- a/TokenTactics.psd1
+++ b/TokenTactics.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'TokenTactics.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.2.22'
+    ModuleVersion     = '0.3.0'
     
     # ID used to uniquely identify this module
     GUID              = '6194f0f0-8b91-4c32-b1b1-bc46c9d7a95c'
@@ -18,7 +18,68 @@
     Description       = 'Azure JSON Web Token ("JWT") Token Manipulation Toolset'
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-    FunctionsToExport = '*'
+    FunctionsToExport = @(
+        'Clear-Token'
+        'ConvertFrom-JWTtoken'
+        'ConvertTo-PEMPrivateKey'
+        'Get-EntraIDAuthorizationCode'
+        'Get-EntraIDToken'
+        'Get-EntraIDTokenFromAuthorizationCode'
+        'Get-EntraIDTokenFromCookie'
+        'Get-EntraIDTokenFromESTSCookie'
+        'Get-EntraIDTokenFromRefreshTokenCredentialCookie'
+        'Get-EntraIDTokenFromSCCAUTHCookie'
+        'Get-ForgedUserAgent'
+        'Get-TenantID'
+        'Invoke-EntraIDPasskeyLogin'
+        'Invoke-RefreshToAzureCoreManagementToken'
+        'Invoke-RefreshToAzureKeyVaultToken'
+        'Invoke-RefreshToAzureManagementToken'
+        'Invoke-RefreshToAzureStorageToken'
+        'Invoke-RefreshToDeviceRegistrationToken'
+        'Invoke-RefreshToDODMSGraphToken'
+        'Invoke-RefreshToGraphToken'
+        'Invoke-RefreshToMAMToken'
+        'Invoke-RefreshToMSGraphToken'
+        'Invoke-RefreshToMSManageToken'
+        'Invoke-RefreshToMSTeamsToken'
+        'Invoke-RefreshToOfficeAppsToken'
+        'Invoke-RefreshToOfficeManagementToken'
+        'Invoke-RefreshToOneDriveToken'
+        'Invoke-RefreshToOutlookToken'
+        'Invoke-RefreshToSharePointToken'
+        'Invoke-RefreshToSubstrateToken'
+        'Invoke-RefreshToYammerToken'
+    )
+
+    AliasesToExport = @(
+        'Parse-JWTtoken'
+        'Forge-UserAgent'
+        'RefreshTo-SubstrateToken'
+        'RefreshTo-MSManageToken'
+        'RefreshTo-MSTeamsToken'
+        'RefreshTo-OfficeManagementToken'
+        'RefreshTo-OutlookToken'
+        'RefreshTo-MSGraphToken'
+        'RefreshTo-GraphToken'
+        'RefreshTo-OfficeAppsToken'
+        'RefreshTo-AzureCoreManagementToken'
+        'RefreshTo-AzureManagementToken'
+        'RefreshTo-MAMToken'
+        'RefreshTo-DODMSGraphToken'
+        'RefreshTo-SharePointToken'
+        'RefreshTo-OneDriveToken'
+        'RefreshTo-YammerToken'
+        'RefreshTo-AzureStorageToken'
+        'RefreshTo-AzureKeyVaultToken'
+        'RefreshTo-DeviceRegistrationToken'
+        'Get-AzureToken'
+        'Get-AzureTokenFromESTSCookie'
+        'Get-AzureTokenFromAuthorizationCode'
+        'Get-AzureAuthorizationCode'
+        'Get-AzureTokenFromCookie'
+        'Get-AzureTokenFromRefreshTokenCredentialCookie'
+    )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData       = @{

--- a/TokenTactics.psm1
+++ b/TokenTactics.psm1
@@ -68,6 +68,7 @@ $functions = @(
     "Invoke-RefreshToOutlookToken"
     "Invoke-RefreshToSharePointToken"
     "Invoke-RefreshToSubstrateToken"
+    "Invoke-RefreshToYammerToken"
 )
 
 $c = 0
@@ -106,4 +107,33 @@ New-Alias -Name Get-AzureAuthorizationCode -Value Get-EntraIDAuthorizationCode
 New-Alias -Name Get-AzureTokenFromCookie -Value Get-EntraIDTokenFromCookie
 New-Alias -Name Get-AzureTokenFromRefreshTokenCredentialCookie -Value Get-EntraIDTokenFromRefreshTokenCredentialCookie
 
-Export-ModuleMember -Alias * -Function *
+$aliases = @(
+    "Parse-JWTtoken"
+    "Forge-UserAgent"
+    "RefreshTo-SubstrateToken"
+    "RefreshTo-MSManageToken"
+    "RefreshTo-MSTeamsToken"
+    "RefreshTo-OfficeManagementToken"
+    "RefreshTo-OutlookToken"
+    "RefreshTo-MSGraphToken"
+    "RefreshTo-GraphToken"
+    "RefreshTo-OfficeAppsToken"
+    "RefreshTo-AzureCoreManagementToken"
+    "RefreshTo-AzureManagementToken"
+    "RefreshTo-MAMToken"
+    "RefreshTo-DODMSGraphToken"
+    "RefreshTo-SharePointToken"
+    "RefreshTo-OneDriveToken"
+    "RefreshTo-YammerToken"
+    "RefreshTo-AzureStorageToken"
+    "RefreshTo-AzureKeyVaultToken"
+    "RefreshTo-DeviceRegistrationToken"
+    "Get-AzureToken"
+    "Get-AzureTokenFromESTSCookie"
+    "Get-AzureTokenFromAuthorizationCode"
+    "Get-AzureAuthorizationCode"
+    "Get-AzureTokenFromCookie"
+    "Get-AzureTokenFromRefreshTokenCredentialCookie"
+)
+
+Export-ModuleMember -Alias $aliases

--- a/modules/ConvertFrom-JWTtoken.ps1
+++ b/modules/ConvertFrom-JWTtoken.ps1
@@ -14,35 +14,38 @@ function ConvertFrom-JWTtoken {
         [string]$token
     )
 
-    if (!$token.Contains(".") -or !$token.StartsWith("eyJ")) { Write-Error "Invalid token" -ErrorAction Stop }
+    $segments = $token.Split('.')
+    if ($segments.Count -ne 3 -or !$token.StartsWith("eyJ")) {
+        Write-Error "Invalid token" -ErrorAction Stop
+    }
 
-    $TokenHeader = $token.Split(".")[0].Replace('-', '+').Replace('_', '/')
+    $TokenHeader = $segments[0].Replace('-', '+').Replace('_', '/')
 
     while ($TokenHeader.Length % 4) {
         $TokenHeader += "="
     }
-    $TokenHeaderObject = [System.Text.Encoding]::ASCII.GetString([system.convert]::FromBase64String($TokenHeader)) | ConvertFrom-Json
+    $TokenHeaderObject = [System.Text.Encoding]::UTF8.GetString([system.convert]::FromBase64String($TokenHeader)) | ConvertFrom-Json
     Write-Verbose ( $TokenHeaderObject  | Out-String -Width 100 )
 
-    $TokenPayload = $token.Split(".")[1].Replace('-', '+').Replace('_', '/')
+    $TokenPayload = $segments[1].Replace('-', '+').Replace('_', '/')
 
     while ($TokenPayload.Length % 4) {
         $TokenPayload += "="
     }
 
-    $tokenArray = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($TokenPayload))
+    $tokenArray = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($TokenPayload))
 
     $TokenObject = $tokenArray | ConvertFrom-Json
-    if (-not [string]::IsNullOrWhiteSpace($TokenObject.iat)) {
-        $TokenObject | Add-Member -NotePropertyName "IssuedAt" -NotePropertyValue (Get-Date "01.01.1970").AddSeconds($TokenObject.iat)
+    if ($null -ne $TokenObject.iat) {
+        $TokenObject | Add-Member -NotePropertyName "IssuedAt" -NotePropertyValue ([DateTimeOffset]::FromUnixTimeSeconds($TokenObject.iat).UtcDateTime)
     }
-    if (-not [string]::IsNullOrWhiteSpace($TokenObject.nbf)) {
-        $TokenObject | Add-Member -NotePropertyName "NotBefore" -NotePropertyValue (Get-Date "01.01.1970").AddSeconds($TokenObject.nbf)
+    if ($null -ne $TokenObject.nbf) {
+        $TokenObject | Add-Member -NotePropertyName "NotBefore" -NotePropertyValue ([DateTimeOffset]::FromUnixTimeSeconds($TokenObject.nbf).UtcDateTime)
     }
-    if (-not [string]::IsNullOrWhiteSpace($TokenObject.exp)) {
-        $TokenObject | Add-Member -NotePropertyName "ExpirationDate" -NotePropertyValue (Get-Date "01.01.1970").AddSeconds($TokenObject.exp)
+    if ($null -ne $TokenObject.exp) {
+        $TokenObject | Add-Member -NotePropertyName "ExpirationDate" -NotePropertyValue ([DateTimeOffset]::FromUnixTimeSeconds($TokenObject.exp).UtcDateTime)
     }
-    if (-not [string]::IsNullOrWhiteSpace($TokenObject.IssuedAt)) {
+    if ($null -ne $TokenObject.IssuedAt -and $null -ne $TokenObject.ExpirationDate) {
         $TokenObject | Add-Member -NotePropertyName "ValidForHours" -NotePropertyValue (New-TimeSpan -Start $TokenObject.IssuedAt -End $TokenObject.ExpirationDate | Select-Object -ExpandProperty TotalHours)
     }
     return $TokenObject

--- a/modules/ConvertTo-PEMPrivateKey.ps1
+++ b/modules/ConvertTo-PEMPrivateKey.ps1
@@ -32,6 +32,19 @@ function ConvertTo-PEMPrivateKey {
         # Replace invalid characters (if any)
         $cleanKey = $cleanKey -replace "-", "+" -replace "_", "/"
 
+        switch ($cleanKey.Length % 4) {
+            0 { }
+            2 { $cleanKey += '==' }
+            3 { $cleanKey += '=' }
+            default { throw "Private key is not valid Base64 or Base64URL data." }
+        }
+
+        try {
+            $null = [Convert]::FromBase64String($cleanKey)
+        } catch {
+            throw "Private key is not valid Base64 or Base64URL data."
+        }
+
         # Wrap at 64 characters
         $wrappedKey = ""
         for ($i = 0; $i -lt $cleanKey.Length; $i += 64) {

--- a/modules/ConvertTo-URLParameters.ps1
+++ b/modules/ConvertTo-URLParameters.ps1
@@ -7,14 +7,24 @@ function ConvertTo-URLParameters {
     )
     $uri = [System.Uri]::new($RequestURL)
     # Get the parameters from the redirect URI and build a hashtable containing the different parameters
-    $query = $uri.Query.TrimStart('?')
     $queryParams = @{}
-    $paramPairs = $query.Split('&')
+    $query = $uri.Query.TrimStart('?')
+    if ([string]::IsNullOrEmpty($query)) {
+        return $queryParams
+    }
 
-    foreach ($pair in $paramPairs) {
-        $parts = $pair.Split('=')
-        $key = $parts[0]
-        $value = $parts[1]
+    foreach ($pair in $query.Split('&')) {
+        if ([string]::IsNullOrEmpty($pair)) {
+            continue
+        }
+
+        $parts = $pair.Split('=', 2)
+        $key = [System.Net.WebUtility]::UrlDecode($parts[0])
+        $value = if ($parts.Count -eq 2) {
+            [System.Net.WebUtility]::UrlDecode($parts[1])
+        } else {
+            ''
+        }
         $queryParams[$key] = $value
     }
     return $queryParams

--- a/modules/Get-EntraErrorDescription.ps1
+++ b/modules/Get-EntraErrorDescription.ps1
@@ -1,0 +1,20 @@
+function Get-EntraErrorDescription {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [System.Management.Automation.ErrorRecord]$ErrorRecord
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ErrorRecord.ErrorDetails.Message)) {
+        try {
+            $details = $ErrorRecord.ErrorDetails.Message | ConvertFrom-Json -ErrorAction Stop
+            if (-not [string]::IsNullOrWhiteSpace($details.error_description)) {
+                return $details.error_description
+            }
+        } catch {
+            return $ErrorRecord.ErrorDetails.Message
+        }
+    }
+
+    return $ErrorRecord.Exception.Message
+}

--- a/modules/Get-EntraIDTokenFromSCCAUTHCookie.ps1
+++ b/modules/Get-EntraIDTokenFromSCCAUTHCookie.ps1
@@ -133,6 +133,8 @@ function Get-EntraIDTokenFromSCCAUTHCookie {
                     if ([string]::IsNullOrWhiteSpace($TenantId)) {
                         $XdrTenantContext = Invoke-RestMethod -Uri "https://security.microsoft.com/apiproxy/mtp/sccManagement/mgmt/TenantContext?realTime=true" -ContentType "application/json" -WebSession $xdrSession -Headers $xdrHeaders
                         $TenantId = $XdrTenantContext.AuthInfo.TenantId
+                        $xdrHeaders["x-tid"] = $TenantId
+                        $xdrHeaders["tenant-id"] = $TenantId
                     }
                     $Resource = "https://$($TenantId)-api.purview-service.microsoft.com"
                     # 73c2949e-da2d-457a-9607-fcc665198967 = Azure Purview

--- a/modules/Get-TenantId.ps1
+++ b/modules/Get-TenantId.ps1
@@ -5,8 +5,18 @@ function Get-TenantID {
         [string]$domain
     )
     Process {
-        $openIdConfig = Invoke-RestMethod "https://login.microsoftonline.com/$domain/.well-known/openid-configuration"
-        $TenantId = $OpenIdConfig.authorization_endpoint.Split("/")[3]
-        return $TenantId
+        $openIdConfig = Invoke-RestMethod -Method Get -Uri "https://login.microsoftonline.com/$domain/.well-known/openid-configuration"
+        if ([string]::IsNullOrWhiteSpace($openIdConfig.authorization_endpoint)) {
+            throw 'The OpenID configuration did not contain an authorization endpoint.'
+        }
+
+        $authorizationEndpoint = [Uri]$openIdConfig.authorization_endpoint
+        $tenantId = $authorizationEndpoint.Segments[1].Trim('/')
+        $parsedTenantId = [Guid]::Empty
+        if (-not [Guid]::TryParse($tenantId, [ref]$parsedTenantId)) {
+            throw "The authorization endpoint did not contain a valid tenant ID: $($openIdConfig.authorization_endpoint)"
+        }
+
+        return $parsedTenantId.ToString()
     }
 }

--- a/modules/Invoke-EntraIDPasskeyLogin.ps1
+++ b/modules/Invoke-EntraIDPasskeyLogin.ps1
@@ -32,14 +32,12 @@ function Invoke-EntraIDPasskeyLogin {
     )
 
     if ($PSVersionTable.PSVersion.Major -lt 7) {
-        Write-Error "This function requires PowerShell 7 (Core) for ECDsa PEM support."
-        exit 1
+        throw "This function requires PowerShell 7 (Core) for ECDsa PEM support."
     }
 
     if ($PSCmdlet.ParameterSetName -eq 'Path') {
         if (-not (Test-Path $KeyFilePath)) {
-            Write-Error "Key file '$KeyFilePath' not found."
-            exit 1
+            throw "Key file '$KeyFilePath' not found."
         }
 
         # Load Key Data
@@ -47,8 +45,7 @@ function Invoke-EntraIDPasskeyLogin {
         try {
             $keyData = Get-Content $KeyFilePath -Raw | ConvertFrom-Json
         } catch {
-            Write-Error "Invalid JSON in key file."
-            exit 1
+            throw "Invalid JSON in key file."
         }
     }
 
@@ -64,8 +61,7 @@ function Invoke-EntraIDPasskeyLogin {
     # Determine Target User
     $targetUser = $keyData.username ?? $UserPrincipalName
     if (-not $targetUser) {
-        Write-Error "Username not found in JSON or arguments."
-        exit 1
+        throw "Username not found in JSON or arguments."
     }
 
     # Determine FIDO Parameters from JSON (Critical for the HAR flow)
@@ -77,13 +73,11 @@ function Invoke-EntraIDPasskeyLogin {
 
     $userHandle = $keyData.userHandle ?? $UserHandle
     if (-not $userHandle) {
-        Write-Error "UserHandle not found in JSON or arguments."
-        exit 1
+        throw "UserHandle not found in JSON or arguments."
     }
     $credentialId = $keyData.credentialId ?? $CredentialId
     if (-not $credentialId) {
-        Write-Error "CredentialId not found in JSON or arguments."
-        exit 1
+        throw "CredentialId not found in JSON or arguments."
     }
     
     # Convert UUID format to base64url if necessary (contains dashes)
@@ -107,12 +101,11 @@ function Invoke-EntraIDPasskeyLogin {
 
     # Private Key and Sign Count
     [int]$SignCount = $keyData.signCount ?? 0
-    $PrivateKeyPem = $keyData.privateKey ?? $keyData.keyValue ?? $PrivateKey
-    $PrivateKeyPem = ConvertTo-PEMPrivateKey -PrivateKey $PrivateKeyPem
-    if (-not $PrivateKeyPem) {
-        Write-Error "Private key not found in JSON or arguments."
-        exit 1
+    $privateKeyValue = $keyData.privateKey ?? $keyData.keyValue ?? $PrivateKey
+    if (-not $privateKeyValue) {
+        throw "Private key not found in JSON or arguments."
     }
+    $PrivateKeyPem = ConvertTo-PEMPrivateKey -PrivateKey $privateKeyValue
 
     #region Authentication Flow
     # Configure Session
@@ -125,12 +118,10 @@ function Invoke-EntraIDPasskeyLogin {
         $uriBuilder = [System.UriBuilder]$authUrl
         $query = [System.Web.HttpUtility]::ParseQueryString($uriBuilder.Query)
     } catch {
-        Write-Error "Invalid auth URL format. $($_.Exception.Message)"
-        exit 1
+        throw "Invalid auth URL format. $($_.Exception.Message)"
     }
     if ( $authUrl -notmatch "^https://login.microsoftonline.com/" ) {
-        Write-Error "Auth URL must start with 'https://login.microsoftonline.com/'"
-        exit 1
+        throw "Auth URL must start with 'https://login.microsoftonline.com/'"
     }
     # Check if required parameters are already present
     # scope
@@ -140,8 +131,7 @@ function Invoke-EntraIDPasskeyLogin {
     $RequiredParams = @("client_id", "response_type", "redirect_uri")
     foreach ($param in $RequiredParams) {
         if (-not $query.Get($param)) {
-            Write-Error "$([char]0x2718) Missing required parameter '$param' in auth URL."
-            exit 1
+            throw "Missing required parameter '$param' in auth URL."
         }
     }
     # Add additional required parameters if missing
@@ -169,16 +159,13 @@ function Invoke-EntraIDPasskeyLogin {
     # B. Validate Credential Type
     Write-Host "$([char]0x2718) Validate FIDO2 Credential Type..." -ForegroundColor Cyan
     if (-not $SessionInformation.oGetCredTypeResult.Credentials.HasFido) {
-        Write-Error "User does not have FIDO credentials registered."
-        exit 1
+        throw "User does not have FIDO credentials registered."
     }
 
     if (-not $SessionInformation.sFidoChallenge) {
-        Write-Error "No FIDO challenge received from server."
-        exit 1
+        throw "No FIDO challenge received from server."
     }
 
-    $serverChallenge = [System.Text.Encoding]::ASCII.GetBytes( $SessionInformation.sFidoChallenge ) # Base64Url challenge from session info
     Write-Host "$([char]0x2714) Challenge Received." -ForegroundColor Green
 
     # C. Local Signing (The "Page 4" equivalent)
@@ -187,7 +174,7 @@ function Invoke-EntraIDPasskeyLogin {
     try {
         $authData = New-FidoAuthenticatorData -RpId $rpId -SignCount $SignCount
         $FidoSignatureParameters = @{
-            Challenge     = (ConvertTo-Base64Url $serverChallenge)
+            Challenge     = $SessionInformation.sFidoChallenge
             Origin        = $origin
             AuthDataBytes = $authData
             PrivateKeyPem = $PrivateKeyPem
@@ -196,17 +183,16 @@ function Invoke-EntraIDPasskeyLogin {
 
         # Construct the payload structure Microsoft expects
         $fidoPayload = [ordered]@{
-            id                = $CredentialId
+            id                = $credentialId
             clientDataJSON    = (ConvertTo-Base64Url $crypto.ClientData)
             authenticatorData = (ConvertTo-Base64Url $authData)
             signature         = (ConvertTo-Base64Url $crypto.Signature)
-            userHandle        = $UserHandle
+            userHandle        = $userHandle
         }
 
         $credentialsJson = $SessionInformation.oGetCredTypeResult.Credentials.FidoParams.AllowList -join ','
     } catch {
-        Write-Error "FIDO Assertion generation failed: $($_.Exception.Message)"
-        exit 1
+        throw "FIDO Assertion generation failed: $($_.Exception.Message)"
     }
 
     Write-Host "$([char]0x2718) Get required pre-information from microsoft.com..." -ForegroundColor Cyan
@@ -238,8 +224,7 @@ function Invoke-EntraIDPasskeyLogin {
         $respVerify.Content -match '{(.*)}' | Out-Null
         $ResponseInformation = $Matches[0] | ConvertFrom-Json
     } catch {
-        Write-Warning "Verification request failed: $($_.Exception.Message)"
-        exit 1
+        throw "Verification request failed: $($_.Exception.Message)"
     }
 
     $LoginUri = "https://login.microsoftonline.com/common/login"
@@ -262,9 +247,7 @@ function Invoke-EntraIDPasskeyLogin {
         $Debug = $Matches[0] | ConvertFrom-Json | ConvertTo-Json -Depth 10
         Write-Debug "$([char]0x2718) Finalization Response: $Debug"
     } catch {
-        Write-Warning "Finalization request failed; checking previous response for success. Error: $($_.Exception.Message)"
-        Write-Debug "$([char]0x2718) Last Response: $($respFinalize | ConvertTo-Json -Depth 10 )"
-        exit 1
+        throw "Finalization request failed: $($_.Exception.Message)"
     }
 
     $LoginUri = "https://login.microsoftonline.com/common/login?sso_reload=true"
@@ -272,8 +255,8 @@ function Invoke-EntraIDPasskeyLogin {
         type         = 23
         ps           = 23
         assertion    = ($fidoPayload | ConvertTo-Json -Compress -Depth 10)
-        lmcCanary    = $lmcCanary.Value
-        hpgrequestid = $hpgrequestid
+        lmcCanary    = $ResponseInformation.sCrossDomainCanary
+        hpgrequestid = $ResponseInformation.sessionId
         ctx          = $SessionInformation.sCtx
         canary       = $SessionInformation.canary
         flowToken    = $SessionInformation.oGetCredTypeResult.FlowToken
@@ -283,9 +266,7 @@ function Invoke-EntraIDPasskeyLogin {
         Write-Host "$([char]0x2718) Submitting FIDO2 assertion to microsoftonline.com with sso_reload=true ..." -ForegroundColor Cyan
         $respFinalize = Invoke-WebRequest -UseBasicParsing -Uri $LoginUri -Method Post -Body $Payload -WebSession $session -MaximumRedirection 0 -SkipHttpErrorCheck
     } catch {
-        Write-Warning "Finalization request failed; checking previous response for success. Error: $($_.Exception.Message)"
-        Write-Debug "$([char]0x2718) Last Response: $($respFinalize)"
-        exit 1
+        throw "Finalization request failed: $($_.Exception.Message)"
     }
 
     $respFinalize.Content -match '{(.*)}' | Out-Null

--- a/modules/Invoke-EntraIDPasskeyLogin.ps1
+++ b/modules/Invoke-EntraIDPasskeyLogin.ps1
@@ -166,6 +166,8 @@ function Invoke-EntraIDPasskeyLogin {
         throw "No FIDO challenge received from server."
     }
 
+    # Microsoft provides the challenge as a string; WebAuthn clientDataJSON expects its bytes as Base64URL.
+    $serverChallenge = [System.Text.Encoding]::ASCII.GetBytes($SessionInformation.sFidoChallenge)
     Write-Host "$([char]0x2714) Challenge Received." -ForegroundColor Green
 
     # C. Local Signing (The "Page 4" equivalent)
@@ -174,7 +176,7 @@ function Invoke-EntraIDPasskeyLogin {
     try {
         $authData = New-FidoAuthenticatorData -RpId $rpId -SignCount $SignCount
         $FidoSignatureParameters = @{
-            Challenge     = $SessionInformation.sFidoChallenge
+            Challenge     = (ConvertTo-Base64Url -Bytes $serverChallenge)
             Origin        = $origin
             AuthDataBytes = $authData
             PrivateKeyPem = $PrivateKeyPem

--- a/modules/TokenHandler.ps1
+++ b/modules/TokenHandler.ps1
@@ -7,7 +7,7 @@ function Get-EntraIDToken {
     #>
     param(
         [Parameter(Mandatory = $False, ParameterSetName = 'CustomUserAgent,PredefinedUserAgent')]
-        [ValidateSet("Yammer", "Outlook", "MSTeams", "Graph", "AzureCoreManagement", "AzureManagement", "MSGraph", "DODMSGraph", "Custom", "Substrate", "SharePoint")]
+        [ValidateSet("Yammer", "Outlook", "MSTeams", "Graph", "AzureCoreManagement", "AzureManagement", "MSGraph", "DODMSGraph", "Custom", "Substrate", "SharePoint", "OneDrive")]
         [string]$Client = "MSGraph",
         [Parameter(Mandatory = $False, ParameterSetName = 'CustomUserAgent,PredefinedUserAgent')]
         [string]$ClientID,
@@ -181,6 +181,10 @@ function Get-EntraIDToken {
             "scope"     = "https://$SharePointTenantName$AdminSuffix.sharepoint.com/Sites.FullControl.All offline_access openid"
         }
     }
+    if ($Client -eq 'SharePoint' -and -not $PSBoundParameters.ContainsKey('SharePointTenantName')) {
+        Write-Error "SharePointTenantName must be provided for the SharePoint client"
+        return
+    }
 
     if ($client -match "DOD") {
         $BaseUrl = "login.microsoftonline.us"
@@ -293,6 +297,8 @@ function Get-EntraIDTokenFromCookie {
         [switch]$UseCodeVerifier,
         [Parameter(Mandatory = $false)]
         [switch]$UseV1Endpoint,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseCAE,
         [Parameter(Mandatory = $false)]
         [string]$Proxy
     )
@@ -514,7 +520,7 @@ function Get-EntraIDTokenFromCookie {
             $global:TokenUpn = $output.upn
             Write-Output "$([char]0x2713)  Token acquired and saved as `$response"
         } catch {
-            Write-Error "Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+            Write-Error "Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
         }
     }
 }
@@ -760,7 +766,7 @@ function Get-EntraIDTokenFromAuthorizationCode {
         [Parameter(Mandatory = $False)]
         [string]$CodeVerifier,
         [Parameter(Mandatory = $False)]
-        [string]$UseV1Endpoint,
+        [switch]$UseV1Endpoint,
         [Parameter(Mandatory = $False)]
         [string]$Resource
     )
@@ -865,7 +871,7 @@ function Get-EntraIDTokenFromAuthorizationCode {
         $global:TokenUpn = $output.upn
         Write-Output "$([char]0x2713)  Token acquired and saved as `$response"
     } catch {
-        Write-Error "Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Error "Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
     #endregion
 }
@@ -977,7 +983,7 @@ function Get-EntraIDAuthorizationCode {
         $CodeVerifierString = "-CodeVerifier `"$CodeVerifier`""
     }
     if ($UseV1Endpoint) {
-        $V1EndpointString = "-Resource $($Resource) -UseV1Endpoint `$$($UseV1Endpoint)"
+        $V1EndpointString = "-Resource `"$Resource`" -UseV1Endpoint"
     }
     if ($Client -eq "Custom") {
         Write-Output "   Get-EntraIDTokenFromAuthorizationCode -Client Custom -RedirectUrl `"$RedirectUrl`" -ClientID `"$ClientID`" -Scope `"$Scope`" -AuthorizationCode `$AuthCode $CodeVerifierString $V1EndpointString"
@@ -1038,7 +1044,7 @@ function Invoke-RefreshToSubstrateToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$SubstrateToken"
         $SubstrateToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1087,7 +1093,7 @@ function Invoke-RefreshToMSManageToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$MSManageToken"
         $MSManageToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1136,7 +1142,7 @@ function Invoke-RefreshToMSTeamsToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$MSTeamsToken"
         $MSTeamsToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1185,7 +1191,7 @@ function Invoke-RefreshToOfficeManagementToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$OfficeManagementToken"
         $OfficeManagementToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1234,7 +1240,7 @@ function Invoke-RefreshToOutlookToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$OutlookToken"
         $OutlookToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1283,7 +1289,7 @@ function Invoke-RefreshToMSGraphToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$MSGraphToken"
         $MSGraphToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1332,7 +1338,7 @@ function Invoke-RefreshToGraphToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$GraphToken"
         $GraphToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1381,7 +1387,7 @@ function Invoke-RefreshToOfficeAppsToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$OfficeAppsToken"
         $OfficeAppsToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1430,7 +1436,7 @@ function Invoke-RefreshToAzureCoreManagementToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$AzureCoreManagementToken"
         $AzureCoreManagementToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1479,7 +1485,7 @@ function Invoke-RefreshToAzureStorageToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$AzureStorageToken"
         $AzureStorageToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1528,7 +1534,7 @@ function Invoke-RefreshToAzureKeyVaultToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$AzureKeyVaultToken"
         $AzureKeyVaultToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1577,7 +1583,7 @@ function Invoke-RefreshToAzureManagementToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$AzureManagementToken"
         $AzureManagementToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1626,7 +1632,7 @@ function Invoke-RefreshToMAMToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$MamToken"
         $MamToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1676,7 +1682,7 @@ function Invoke-RefreshToDODMSGraphToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$DODMSGraphToken"
         $DODMSGraphToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1736,7 +1742,7 @@ function Invoke-RefreshToSharePointToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$SharePointToken"
         $SharePointToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 function Invoke-RefreshToOneDriveToken {
@@ -1784,7 +1790,7 @@ function Invoke-RefreshToOneDriveToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$OneDriveToken"
         $OneDriveToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1825,7 +1831,7 @@ function Invoke-RefreshToYammerToken {
         Device          = $Device
         Browser         = $Browser
         UseCAE          = $UseCAE
-        Scope           = "https://api.spaces.skype.com/.default offline_access openid"
+        Scope           = "https://www.yammer.com/.default offline_access openid"
     }
 
     try {
@@ -1833,7 +1839,7 @@ function Invoke-RefreshToYammerToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$YammerToken"
         $YammerToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1884,7 +1890,7 @@ function Invoke-RefreshToDeviceRegistrationToken {
         Write-Output "$([char]0x2713)  Token acquired and saved as `$DeviceRegistrationToken"
         $DeviceRegistrationToken | Select-Object token_type, scope, expires_in, ext_expires_in | Format-List
     } catch {
-        Write-Output "$([char]0x274C) Could not get tokens $($_.ErrorDetails | ConvertFrom-Json | Select-Object -ExpandProperty error_description)"
+        Write-Output "$([char]0x274C) Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
     }
 }
 
@@ -1984,55 +1990,40 @@ function Clear-Token {
         Clear-Token -Token Substrate
     #>
     [CmdletBinding()]
-    param([Parameter(Mandatory = $true)]
-        [ValidateSet("All", "Response", "Outlook", "MSTeams", "Graph", "AzureCoreManagement", "OfficeManagement", "MSGraph", "DODMSGraph", "Custom", "Substrate", "SharePoint", "OneDrive", "Yammer")]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("All", "Response", "Outlook", "MSTeams", "Graph", "AzureCoreManagement", "AzureManagement", "AzureStorage", "AzureKeyVault", "OfficeManagement", "OfficeApps", "MSGraph", "MSManage", "DODMSGraph", "MAM", "Custom", "Substrate", "SharePoint", "OneDrive", "Yammer", "DeviceRegistration")]
         [string]$Token
     )
-    if ($Token -eq "All") {
-        # Remove variables from the global scope
-        Remove-Variable -Scope Global -Name response -ErrorAction 0
-        Remove-Variable -Scope Global -Name OutlookToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name MSTeamsToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name GraphToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name AzureCoreManagementToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name OfficeManagementToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name MSGraphToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name DODMSGraphToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name CustomToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name SubstrateToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name CustomToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name SharePointToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name YammerToken -ErrorAction 0
-        Remove-Variable -Scope Global -Name DeviceRegistrationToken -ErrorAction 0
-    } elseif ($Token -eq "Response") {
-        Remove-Variable -Scope Global -Name response -ErrorAction 0
-    } elseif ($Token -eq "Outlook") {
-        Remove-Variable -Scope Global -Name OutlookToken -ErrorAction 0
-    } elseif ($Token -eq "MSTeams") {
-        Remove-Variable -Scope Global -Name MSTeamsToken -ErrorAction 0
-    } elseif ($Token -eq "Graph") {
-        Remove-Variable -Scope Global -Name GraphToken -ErrorAction 0
-    } elseif ($Token -eq "AzureCoreManagement") {
-        Remove-Variable -Scope Global -Name AzureCoreManagementToken -ErrorAction 0
-    } elseif ($Token -eq "OfficeManagement") {
-        Remove-Variable -Scope Global -Name OfficeManagementToken -ErrorAction 0
-    } elseif ($Token -eq "MSGraph") {
-        Remove-Variable -Scope Global -Name MSGraphToken -ErrorAction 0
-    } elseif ($Token -eq "DODMSGraph") {
-        Remove-Variable -Scope Global -Name DODMSGraphToken -ErrorAction 0
-    } elseif ($Token -eq "Custom") {
-        Remove-Variable -Scope Global -Name CustomToken -ErrorAction 0
-    } elseif ($Token -eq "Substrate") {
-        Remove-Variable -Scope Global -Name SubstrateToken -ErrorAction 0
-    } elseif ( $Token -eq "SharePoint") {
-        Remove-Variable -Scope Global -Name SharePointToken -ErrorAction 0
-    } elseif ( $Token -eq "OneDrive") {
-        Remove-Variable -Scope Global -Name OneDriveToken -ErrorAction 0
-    } elseif ( $Token -eq "Yammer") {
-        Remove-Variable -Scope Global -Name YammerToken -ErrorAction 0
-    } elseif ( $Token -eq "DeviceRegistration") {
-        Remove-Variable -Scope Global -Name DeviceRegistrationToken -ErrorAction 0
-    } else {
-        Write-Error "Token $Token not found"
+
+    $tokenVariables = @{
+        Response            = 'response'
+        Outlook             = 'OutlookToken'
+        MSTeams             = 'MSTeamsToken'
+        Graph               = 'GraphToken'
+        AzureCoreManagement = 'AzureCoreManagementToken'
+        AzureManagement     = 'AzureManagementToken'
+        AzureStorage        = 'AzureStorageToken'
+        AzureKeyVault       = 'AzureKeyVaultToken'
+        OfficeManagement    = 'OfficeManagementToken'
+        OfficeApps          = 'OfficeAppsToken'
+        MSGraph             = 'MSGraphToken'
+        MSManage            = 'MSManageToken'
+        DODMSGraph          = 'DODMSGraphToken'
+        MAM                 = 'MAMToken'
+        Custom              = 'CustomToken'
+        Substrate           = 'SubstrateToken'
+        SharePoint          = 'SharePointToken'
+        OneDrive            = 'OneDriveToken'
+        Yammer              = 'YammerToken'
+        DeviceRegistration  = 'DeviceRegistrationToken'
     }
+
+    $variablesToRemove = if ($Token -eq 'All') {
+        $tokenVariables.Values
+    } else {
+        @($tokenVariables[$Token])
+    }
+
+    Remove-Variable -Scope Global -Name $variablesToRemove -ErrorAction SilentlyContinue
 }

--- a/tests/AuthenticationFlows.Tests.ps1
+++ b/tests/AuthenticationFlows.Tests.ps1
@@ -1,0 +1,482 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+
+    $script:TestUserAgent = 'TokenTactics-Test/1.0'
+    $script:TokenResponse = [PSCustomObject]@{
+        access_token  = $script:FakeAccessToken
+        refresh_token = $script:FakeRefreshToken
+        token_type    = 'Bearer'
+        expires_in    = 3600
+    }
+}
+
+Describe 'Get-EntraIDToken device-code flow' {
+    BeforeEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn', 'AuthenticationFlowPollAttempt') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+        Mock -ModuleName TokenTactics Get-ForgedUserAgent { 'TokenTactics-Test/1.0' }
+    }
+
+    AfterEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn', 'AuthenticationFlowPollAttempt') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'requests and exchanges a OneDrive device code using the exact contracts' {
+        $deviceResponse = [PSCustomObject]@{
+            device_code = 'one-drive-device-code'
+            user_code   = 'ABCD-EFGH'
+            interval    = 4
+            expires_in  = 900
+        }
+
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw "Unexpected REST request: $Method $Uri" }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $deviceResponse } -ParameterFilter {
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/devicecode' -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            $Headers -is [System.Collections.IDictionary] -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'TokenTactics-Test/1.0' -and
+            $Body -is [System.Collections.IDictionary] -and
+            $Body.Count -eq 2 -and
+            $Body['client_id'] -eq 'ab9b8c07-8f02-4f72-87fa-80105867a763' -and
+            $Body['scope'] -eq 'https://officeapps.live.com/.default offline_access openid'
+        }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $script:TokenResponse } -ParameterFilter {
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/token' -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            $Headers -is [System.Collections.IDictionary] -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'TokenTactics-Test/1.0' -and
+            $Body -is [System.Collections.IDictionary] -and
+            $Body.Count -eq 3 -and
+            $Body['client_id'] -eq 'ab9b8c07-8f02-4f72-87fa-80105867a763' -and
+            $Body['grant_type'] -eq 'urn:ietf:params:oauth:grant-type:device_code' -and
+            $Body['device_code'] -eq 'one-drive-device-code'
+        }
+        Mock -ModuleName TokenTactics Start-Sleep {} -ParameterFilter { $Seconds -eq 4 }
+
+        Get-EntraIDToken -Client OneDrive
+
+        $global:response.access_token | Should -Be $script:FakeAccessToken
+        $global:TokenDomain | Should -Be 'contoso.com'
+        $global:TokenUpn | Should -Be 'test.user@contoso.com'
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 2
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/devicecode' -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'TokenTactics-Test/1.0' -and
+            $Body.Count -eq 2 -and
+            $Body['client_id'] -eq 'ab9b8c07-8f02-4f72-87fa-80105867a763' -and
+            $Body['scope'] -eq 'https://officeapps.live.com/.default offline_access openid'
+        }
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/token' -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'TokenTactics-Test/1.0' -and
+            $Body.Count -eq 3 -and
+            $Body['client_id'] -eq 'ab9b8c07-8f02-4f72-87fa-80105867a763' -and
+            $Body['grant_type'] -eq 'urn:ietf:params:oauth:grant-type:device_code' -and
+            $Body['device_code'] -eq 'one-drive-device-code'
+        }
+        Should -Invoke Start-Sleep -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $Seconds -eq 4
+        }
+    }
+
+    It 'polls again after authorization_pending and then succeeds' {
+        $global:AuthenticationFlowPollAttempt = 0
+        $deviceResponse = [PSCustomObject]@{
+            device_code = 'pending-device-code'
+            user_code   = 'PEND-ING1'
+            interval    = 2
+            expires_in  = 900
+        }
+
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw "Unexpected REST request: $Method $Uri" }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $deviceResponse } -ParameterFilter {
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/devicecode' -and
+            "$Method" -eq 'Post' -and
+            $Body['client_id'] -eq 'ab9b8c07-8f02-4f72-87fa-80105867a763' -and
+            $Body['scope'] -eq 'https://officeapps.live.com/.default offline_access openid'
+        }
+        Mock -ModuleName TokenTactics Invoke-RestMethod {
+            if ($global:AuthenticationFlowPollAttempt -eq 0) {
+                $global:AuthenticationFlowPollAttempt++
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [System.InvalidOperationException]::new('Authorization is pending'),
+                    'authorization_pending',
+                    [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                    $null
+                )
+                $errorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new(
+                    '{"error":"authorization_pending","error_description":"Authorization is pending"}'
+                )
+                throw $errorRecord
+            }
+
+            $global:AuthenticationFlowPollAttempt++
+            return $script:TokenResponse
+        } -ParameterFilter {
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/token' -and
+            "$Method" -eq 'Post' -and
+            $Body.Count -eq 3 -and
+            $Body['client_id'] -eq 'ab9b8c07-8f02-4f72-87fa-80105867a763' -and
+            $Body['grant_type'] -eq 'urn:ietf:params:oauth:grant-type:device_code' -and
+            $Body['device_code'] -eq 'pending-device-code'
+        }
+        Mock -ModuleName TokenTactics Start-Sleep {} -ParameterFilter { $Seconds -eq 2 }
+
+        Get-EntraIDToken -Client OneDrive
+
+        $global:response.access_token | Should -Be $script:FakeAccessToken
+        $global:AuthenticationFlowPollAttempt | Should -Be 2
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 3
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/devicecode' -and
+            "$Method" -eq 'Post' -and
+            $Body.Count -eq 2 -and
+            $Body['client_id'] -eq 'ab9b8c07-8f02-4f72-87fa-80105867a763' -and
+            $Body['scope'] -eq 'https://officeapps.live.com/.default offline_access openid'
+        }
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 2 -ParameterFilter {
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/token' -and
+            "$Method" -eq 'Post' -and
+            $Body.Count -eq 3 -and
+            $Body['client_id'] -eq 'ab9b8c07-8f02-4f72-87fa-80105867a763' -and
+            $Body['grant_type'] -eq 'urn:ietf:params:oauth:grant-type:device_code' -and
+            $Body['device_code'] -eq 'pending-device-code'
+        }
+        Should -Invoke Start-Sleep -ModuleName TokenTactics -Exactly -Scope It -Times 2 -ParameterFilter {
+            $Seconds -eq 2
+        }
+    }
+
+    It 'rejects SharePoint without a tenant name before making an HTTP request' {
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw "Unexpected REST request: $Method $Uri" }
+
+        { Get-EntraIDToken -Client SharePoint -ErrorAction Stop } |
+            Should -Throw '*SharePointTenantName must be provided*'
+
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 0
+    }
+}
+
+Describe 'Get-EntraIDTokenFromCookie authorization-code flow' {
+    BeforeEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+    }
+
+    AfterEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'URL-decodes a 302 authorization code and exchanges it with CAE claims' {
+        $redirectUrl = 'https://app.example/callback'
+        $decodedCode = 'encoded+authorization/code=value'
+        $claims = '{"access_token":{"xms_cc":{"values":["cp1"]}}}'
+
+        Mock -ModuleName TokenTactics Invoke-WebRequest { throw "Unexpected web request: $Method $Uri" }
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            [PSCustomObject]@{ StatusCode = 200; RawContent = ''; Headers = @{} }
+        } -ParameterFilter {
+            $UseBasicParsing -and
+            -not $SkipHttpErrorCheck -and
+            $MaximumRedirection -eq 0 -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            $WebSession -is [Microsoft.PowerShell.Commands.WebRequestSession] -and
+            "$Method" -eq 'Get' -and
+            "$Uri" -eq 'https://login.microsoftonline.com/error'
+        }
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            [PSCustomObject]@{
+                StatusCode = 302
+                RawContent = ''
+                Headers    = @{
+                    Location = [string[]]@(
+                        'https://app.example/callback?code=encoded%2Bauthorization%2Fcode%3Dvalue&state=returned-state'
+                    )
+                }
+            }
+        } -ParameterFilter {
+            $parsedUri = [Uri]$Uri
+            $query = [System.Web.HttpUtility]::ParseQueryString($parsedUri.Query)
+            $UseBasicParsing -and
+            $SkipHttpErrorCheck -and
+            $MaximumRedirection -eq 0 -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            $WebSession -is [Microsoft.PowerShell.Commands.WebRequestSession] -and
+            "$Method" -eq 'Get' -and
+            $parsedUri.Scheme -eq 'https' -and
+            $parsedUri.Host -eq 'login.microsoftonline.com' -and
+            $parsedUri.AbsolutePath -eq '/common/oauth2/v2.0/authorize' -and
+            $Headers -is [System.Collections.IDictionary] -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'TokenTactics-Test/1.0' -and
+            $query.Count -eq 6 -and
+            $query['response_type'] -eq 'code' -and
+            $query['client_id'] -eq 'cookie-client-id' -and
+            $query['scope'] -eq 'openid offline_access' -and
+            $query['redirect_uri'] -eq 'https://app.example/callback' -and
+            $query['state'] -match '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' -and
+            $query['claims'] -eq '{"access_token":{"xms_cc":{"values":["cp1"]}}}'
+        }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw "Unexpected REST request: $Method $Uri" }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $script:TokenResponse } -ParameterFilter {
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/token' -and
+            $Headers -is [System.Collections.IDictionary] -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'TokenTactics-Test/1.0' -and
+            $Body -is [System.Collections.IDictionary] -and
+            $Body.Count -eq 6 -and
+            $Body['client_id'] -eq 'cookie-client-id' -and
+            $Body['grant_type'] -eq 'authorization_code' -and
+            $Body['redirect_uri'] -eq 'https://app.example/callback' -and
+            $Body['code'] -eq 'encoded+authorization/code=value' -and
+            $Body['scope'] -eq 'openid offline_access' -and
+            $Body['claims'] -eq '{"access_token":{"xms_cc":{"values":["cp1"]}}}'
+        }
+
+        Get-EntraIDTokenFromCookie `
+            -CookieType ESTSAUTHPERSISTENT `
+            -CookieValue 'test-cookie-value' `
+            -ClientID 'cookie-client-id' `
+            -Resource 'https://graph.microsoft.com' `
+            -Scope 'openid offline_access' `
+            -RedirectUrl $redirectUrl `
+            -CustomUserAgent $script:TestUserAgent `
+            -UseCAE
+
+        $global:response.access_token | Should -Be $script:FakeAccessToken
+        $global:TokenDomain | Should -Be 'contoso.com'
+        $global:TokenUpn | Should -Be 'test.user@contoso.com'
+        Should -Invoke Invoke-WebRequest -ModuleName TokenTactics -Exactly -Scope It -Times 2
+        Should -Invoke Invoke-WebRequest -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $UseBasicParsing -and
+            -not $SkipHttpErrorCheck -and
+            $MaximumRedirection -eq 0 -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            "$Method" -eq 'Get' -and
+            "$Uri" -eq 'https://login.microsoftonline.com/error'
+        }
+        Should -Invoke Invoke-WebRequest -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $parsedUri = [Uri]$Uri
+            $query = [System.Web.HttpUtility]::ParseQueryString($parsedUri.Query)
+            $UseBasicParsing -and
+            $SkipHttpErrorCheck -and
+            $MaximumRedirection -eq 0 -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            "$Method" -eq 'Get' -and
+            $parsedUri.Host -eq 'login.microsoftonline.com' -and
+            $parsedUri.AbsolutePath -eq '/common/oauth2/v2.0/authorize' -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'TokenTactics-Test/1.0' -and
+            $query.Count -eq 6 -and
+            $query['response_type'] -eq 'code' -and
+            $query['client_id'] -eq 'cookie-client-id' -and
+            $query['scope'] -eq 'openid offline_access' -and
+            $query['redirect_uri'] -eq 'https://app.example/callback' -and
+            $query['state'] -match '^[0-9a-f-]{36}$' -and
+            $query['claims'] -eq '{"access_token":{"xms_cc":{"values":["cp1"]}}}'
+        }
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 1
+        Should -Invoke Invoke-RestMethod -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            "$Uri" -eq 'https://login.microsoftonline.com/common/oauth2/v2.0/token' -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'TokenTactics-Test/1.0' -and
+            $Body.Count -eq 6 -and
+            $Body['client_id'] -eq 'cookie-client-id' -and
+            $Body['grant_type'] -eq 'authorization_code' -and
+            $Body['redirect_uri'] -eq $redirectUrl -and
+            $Body['code'] -eq $decodedCode -and
+            $Body['scope'] -eq 'openid offline_access' -and
+            $Body['claims'] -eq $claims
+        }
+    }
+}
+
+Describe 'Cookie convenience wrappers' {
+    BeforeEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+    }
+
+    AfterEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'passes the exact ESTS cookie, client, user-agent, proxy, and resource arguments' {
+        Mock -ModuleName TokenTactics Get-EntraIDTokenFromCookie { throw 'Unexpected delegation arguments' }
+        Mock -ModuleName TokenTactics Get-EntraIDTokenFromCookie {} -ParameterFilter {
+            $CookieType -eq 'ESTSAUTH' -and
+            $CookieValue -eq 'ests-cookie-value' -and
+            $ClientID -eq 'custom-ests-client' -and
+            $CustomUserAgent -eq 'Delegation-Agent/2.0' -and
+            $Proxy -eq 'http://127.0.0.1:8080' -and
+            $Resource -eq 'https://resource.example' -and
+            $Scope -eq 'api://resource/.default' -and
+            $RedirectUrl -eq 'https://app.example/ests-callback' -and
+            $null -eq $Device -and
+            $null -eq $Browser
+        }
+
+        Get-EntraIDTokenFromESTSCookie `
+            -CookieValue 'ests-cookie-value' `
+            -ESTSCookieType ESTSAUTH `
+            -Client Custom `
+            -ClientID 'custom-ests-client' `
+            -CustomUserAgent 'Delegation-Agent/2.0' `
+            -Proxy 'http://127.0.0.1:8080' `
+            -Resource 'https://resource.example' `
+            -Scope 'api://resource/.default' `
+            -RedirectUrl 'https://app.example/ests-callback'
+
+        Should -Invoke Get-EntraIDTokenFromCookie -ModuleName TokenTactics -Exactly -Scope It -Times 1
+        Should -Invoke Get-EntraIDTokenFromCookie -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $CookieType -eq 'ESTSAUTH' -and
+            $CookieValue -eq 'ests-cookie-value' -and
+            $ClientID -eq 'custom-ests-client' -and
+            $CustomUserAgent -eq 'Delegation-Agent/2.0' -and
+            $Proxy -eq 'http://127.0.0.1:8080' -and
+            $Resource -eq 'https://resource.example' -and
+            $Scope -eq 'api://resource/.default' -and
+            $RedirectUrl -eq 'https://app.example/ests-callback' -and
+            $null -eq $Device -and
+            $null -eq $Browser
+        }
+    }
+
+    It 'passes the exact refresh-token credential cookie type, value, and client arguments' {
+        Mock -ModuleName TokenTactics Get-EntraIDTokenFromCookie { throw 'Unexpected delegation arguments' }
+        Mock -ModuleName TokenTactics Get-EntraIDTokenFromCookie {} -ParameterFilter {
+            $CookieType -eq 'x-ms-RefreshTokenCredential' -and
+            $CookieValue -eq 'refresh-token-credential-value' -and
+            $ClientID -eq 'custom-refresh-client' -and
+            $CustomUserAgent -eq 'Refresh-Agent/3.0' -and
+            $Resource -eq 'https://graph.microsoft.com' -and
+            $Scope -eq 'openid offline_access' -and
+            $RedirectUrl -eq 'https://app.example/refresh-callback' -and
+            $null -eq $Proxy -and
+            $null -eq $Device -and
+            $null -eq $Browser
+        }
+
+        Get-EntraIDTokenFromRefreshTokenCredentialCookie `
+            -RefreshTokenCredential 'refresh-token-credential-value' `
+            -Client Custom `
+            -ClientID 'custom-refresh-client' `
+            -CustomUserAgent 'Refresh-Agent/3.0' `
+            -RedirectUrl 'https://app.example/refresh-callback'
+
+        Should -Invoke Get-EntraIDTokenFromCookie -ModuleName TokenTactics -Exactly -Scope It -Times 1
+        Should -Invoke Get-EntraIDTokenFromCookie -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $CookieType -eq 'x-ms-RefreshTokenCredential' -and
+            $CookieValue -eq 'refresh-token-credential-value' -and
+            $ClientID -eq 'custom-refresh-client' -and
+            $CustomUserAgent -eq 'Refresh-Agent/3.0' -and
+            $Resource -eq 'https://graph.microsoft.com' -and
+            $Scope -eq 'openid offline_access' -and
+            $RedirectUrl -eq 'https://app.example/refresh-callback' -and
+            $null -eq $Proxy -and
+            $null -eq $Device -and
+            $null -eq $Browser
+        }
+    }
+}
+
+Describe 'Get-EntraIDAuthorizationCode URL construction' {
+    BeforeEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+        Mock -ModuleName TokenTactics Start-Process { throw 'Browser operation was not expected' }
+        Mock -ModuleName TokenTactics Set-Clipboard { throw 'Clipboard operation was not expected' }
+    }
+
+    AfterEach {
+        Should -Invoke Start-Process -ModuleName TokenTactics -Exactly -Scope It -Times 0
+        Should -Invoke Set-Clipboard -ModuleName TokenTactics -Exactly -Scope It -Times 0
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'constructs the exact custom-client v2 URL' {
+        $output = @(Get-EntraIDAuthorizationCode `
+                -Client Custom `
+                -ClientID 'custom-client' `
+                -Scope 'api://custom/.default offline_access' `
+                -RedirectUrl 'https://app.example/callback' `
+                -AuthorizationCodeState 'fixed-state')
+
+        $output[0] | Should -Be 'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?response_type=code&redirect_uri=https://app.example/callback&state=fixed-state&scope=api://custom/.default%20offline_access&client_id=custom-client'
+    }
+
+    It 'constructs the exact v1 URL with its resource' {
+        $output = @(Get-EntraIDAuthorizationCode `
+                -Client MSGraph `
+                -ClientID 'v1-client' `
+                -RedirectUrl 'https://app.example/v1-callback' `
+                -AuthorizationCodeState 'v1-state' `
+                -UseV1Endpoint `
+                -Resource 'https://resource.example')
+
+        $output[0] | Should -Be 'https://login.microsoftonline.com/organizations/oauth2/authorize?response_type=code&redirect_uri=https://app.example/v1-callback&state=v1-state&resource=https://resource.example&scope=https://graph.microsoft.com/.default%20offline_access%20openid&client_id=v1-client'
+        $output[-1] | Should -Match 'Get-EntraIDTokenFromAuthorizationCode.*-Resource "https://resource\.example" -UseV1Endpoint$'
+    }
+
+    It 'constructs the exact CAE URL with the cp1 claim' {
+        $output = @(Get-EntraIDAuthorizationCode `
+                -Client MSGraph `
+                -ClientID 'cae-client' `
+                -RedirectUrl 'https://app.example/cae-callback' `
+                -AuthorizationCodeState 'cae-state' `
+                -UseCAE)
+
+        $output[0] | Should -Be 'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?response_type=code&redirect_uri=https://app.example/cae-callback&state=cae-state&scope=https://graph.microsoft.com/.default%20offline_access%20openid&client_id=cae-client&claims=%7B%22access_token%22:%7B%22xms_cc%22:%7B%22values%22:[%22cp1%22]%7D%7D%7D'
+    }
+
+    It 'constructs the exact PKCE URL from deterministic verifier helpers' {
+        Mock -ModuleName TokenTactics Get-TTCodeVerifier { 'fixed-code-verifier' }
+        Mock -ModuleName TokenTactics Get-TTCodeChallenge { 'fixed-code-challenge' } -ParameterFilter {
+            $CodeVerifier -eq 'fixed-code-verifier'
+        }
+
+        $output = @(Get-EntraIDAuthorizationCode `
+                -Client MSGraph `
+                -ClientID 'pkce-client' `
+                -RedirectUrl 'https://app.example/pkce-callback' `
+                -AuthorizationCodeState 'pkce-state' `
+                -UseCodeVerifier)
+
+        $output[0] | Should -Be 'https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?response_type=code&redirect_uri=https://app.example/pkce-callback&state=pkce-state&code_challenge=fixed-code-challenge&code_challenge_method=S256&scope=https://graph.microsoft.com/.default%20offline_access%20openid&client_id=pkce-client'
+        Should -Invoke Get-TTCodeVerifier -ModuleName TokenTactics -Exactly -Scope It -Times 1
+        Should -Invoke Get-TTCodeChallenge -ModuleName TokenTactics -Exactly -Scope It -Times 1 -ParameterFilter {
+            $CodeVerifier -eq 'fixed-code-verifier'
+        }
+    }
+}

--- a/tests/Clear-Token.Tests.ps1
+++ b/tests/Clear-Token.Tests.ps1
@@ -1,0 +1,106 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "Clear-Token" {
+    BeforeEach {
+        # Pre-set all global token variables
+        $global:response              = [PSCustomObject]@{ access_token = "fake" }
+        $global:OutlookToken          = [PSCustomObject]@{ access_token = "fake" }
+        $global:MSTeamsToken          = [PSCustomObject]@{ access_token = "fake" }
+        $global:GraphToken            = [PSCustomObject]@{ access_token = "fake" }
+        $global:AzureCoreManagementToken = [PSCustomObject]@{ access_token = "fake" }
+        $global:OfficeManagementToken = [PSCustomObject]@{ access_token = "fake" }
+        $global:MSGraphToken          = [PSCustomObject]@{ access_token = "fake" }
+        $global:DODMSGraphToken       = [PSCustomObject]@{ access_token = "fake" }
+        $global:CustomToken           = [PSCustomObject]@{ access_token = "fake" }
+        $global:SubstrateToken        = [PSCustomObject]@{ access_token = "fake" }
+        $global:SharePointToken       = [PSCustomObject]@{ access_token = "fake" }
+        $global:YammerToken           = [PSCustomObject]@{ access_token = "fake" }
+        $global:DeviceRegistrationToken = [PSCustomObject]@{ access_token = "fake" }
+    }
+
+    AfterEach {
+        # Clean up any remaining global variables
+        Remove-Variable -Scope Global -Name response              -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name OutlookToken          -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name MSTeamsToken          -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name GraphToken            -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name AzureCoreManagementToken -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name OfficeManagementToken -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name MSGraphToken          -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name DODMSGraphToken       -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name CustomToken           -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name SubstrateToken        -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name SharePointToken       -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name YammerToken           -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name DeviceRegistrationToken -ErrorAction SilentlyContinue
+    }
+
+    Context "Clear-Token -Token All" {
+        It "Removes the `$response global variable" {
+            Clear-Token -Token All
+            { Get-Variable -Scope Global -Name response -ErrorAction Stop } | Should -Throw
+        }
+
+        It "Removes the `$MSTeamsToken global variable" {
+            Clear-Token -Token All
+            { Get-Variable -Scope Global -Name MSTeamsToken -ErrorAction Stop } | Should -Throw
+        }
+
+        It "Removes the `$MSGraphToken global variable" {
+            Clear-Token -Token All
+            { Get-Variable -Scope Global -Name MSGraphToken -ErrorAction Stop } | Should -Throw
+        }
+
+        It "Removes the `$SubstrateToken global variable" {
+            Clear-Token -Token All
+            { Get-Variable -Scope Global -Name SubstrateToken -ErrorAction Stop } | Should -Throw
+        }
+    }
+
+    Context "Clear-Token -Token specific" {
+        It "Removes only `$MSTeamsToken when -Token MSTeams is specified" {
+            Clear-Token -Token MSTeams
+            { Get-Variable -Scope Global -Name MSTeamsToken -ErrorAction Stop } | Should -Throw
+            # Other tokens should still exist
+            $global:response | Should -Not -BeNullOrEmpty
+        }
+
+        It "Removes only `$response when -Token Response is specified" {
+            Clear-Token -Token Response
+            { Get-Variable -Scope Global -Name response -ErrorAction Stop } | Should -Throw
+            $global:MSTeamsToken | Should -Not -BeNullOrEmpty
+        }
+
+        It "Removes only `$MSGraphToken when -Token MSGraph is specified" {
+            Clear-Token -Token MSGraph
+            { Get-Variable -Scope Global -Name MSGraphToken -ErrorAction Stop } | Should -Throw
+            $global:response | Should -Not -BeNullOrEmpty
+        }
+
+        It "Removes only `$OutlookToken when -Token Outlook is specified" {
+            Clear-Token -Token Outlook
+            { Get-Variable -Scope Global -Name OutlookToken -ErrorAction Stop } | Should -Throw
+            $global:response | Should -Not -BeNullOrEmpty
+        }
+
+        It "Removes only `$GraphToken when -Token Graph is specified" {
+            Clear-Token -Token Graph
+            { Get-Variable -Scope Global -Name GraphToken -ErrorAction Stop } | Should -Throw
+            $global:response | Should -Not -BeNullOrEmpty
+        }
+
+        It "Removes only `$SharePointToken when -Token SharePoint is specified" {
+            Clear-Token -Token SharePoint
+            { Get-Variable -Scope Global -Name SharePointToken -ErrorAction Stop } | Should -Throw
+            $global:response | Should -Not -BeNullOrEmpty
+        }
+
+        It "Does not throw when the variable does not already exist" {
+            Remove-Variable -Scope Global -Name MSTeamsToken -ErrorAction SilentlyContinue
+            { Clear-Token -Token MSTeams } | Should -Not -Throw
+        }
+    }
+}

--- a/tests/Clear-Token.Tests.ps1
+++ b/tests/Clear-Token.Tests.ps1
@@ -1,106 +1,86 @@
+$tokenCases = @(
+    @{ Token = 'Response'; Variable = 'response' }
+    @{ Token = 'Outlook'; Variable = 'OutlookToken' }
+    @{ Token = 'MSTeams'; Variable = 'MSTeamsToken' }
+    @{ Token = 'Graph'; Variable = 'GraphToken' }
+    @{ Token = 'AzureCoreManagement'; Variable = 'AzureCoreManagementToken' }
+    @{ Token = 'AzureManagement'; Variable = 'AzureManagementToken' }
+    @{ Token = 'AzureStorage'; Variable = 'AzureStorageToken' }
+    @{ Token = 'AzureKeyVault'; Variable = 'AzureKeyVaultToken' }
+    @{ Token = 'OfficeManagement'; Variable = 'OfficeManagementToken' }
+    @{ Token = 'OfficeApps'; Variable = 'OfficeAppsToken' }
+    @{ Token = 'MSGraph'; Variable = 'MSGraphToken' }
+    @{ Token = 'MSManage'; Variable = 'MSManageToken' }
+    @{ Token = 'DODMSGraph'; Variable = 'DODMSGraphToken' }
+    @{ Token = 'MAM'; Variable = 'MAMToken' }
+    @{ Token = 'Custom'; Variable = 'CustomToken' }
+    @{ Token = 'Substrate'; Variable = 'SubstrateToken' }
+    @{ Token = 'SharePoint'; Variable = 'SharePointToken' }
+    @{ Token = 'OneDrive'; Variable = 'OneDriveToken' }
+    @{ Token = 'Yammer'; Variable = 'YammerToken' }
+    @{ Token = 'DeviceRegistration'; Variable = 'DeviceRegistrationToken' }
+)
+
 BeforeAll {
     . "$PSScriptRoot/fixtures/TestData.ps1"
     Import-Module $script:ModulePath -Force
+
+    $script:TokenVariables = @(
+        'response', 'OutlookToken', 'MSTeamsToken', 'GraphToken',
+        'AzureCoreManagementToken', 'AzureManagementToken', 'AzureStorageToken',
+        'AzureKeyVaultToken', 'OfficeManagementToken', 'OfficeAppsToken',
+        'MSGraphToken', 'MSManageToken', 'DODMSGraphToken', 'MAMToken',
+        'CustomToken', 'SubstrateToken', 'SharePointToken', 'OneDriveToken',
+        'YammerToken', 'DeviceRegistrationToken'
+    )
+    $script:OriginalGlobals = @{}
+    foreach ($name in $script:TokenVariables) {
+        $existing = Get-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        if ($existing) {
+            $script:OriginalGlobals[$name] = $existing.Value
+        }
+    }
 }
 
-Describe "Clear-Token" {
+AfterAll {
+    if ($script:TokenVariables) {
+        Remove-Variable -Scope Global -Name $script:TokenVariables -ErrorAction SilentlyContinue
+    }
+    foreach ($entry in $script:OriginalGlobals.GetEnumerator()) {
+        Set-Variable -Scope Global -Name $entry.Key -Value $entry.Value
+    }
+}
+
+Describe 'Clear-Token' {
     BeforeEach {
-        # Pre-set all global token variables
-        $global:response              = [PSCustomObject]@{ access_token = "fake" }
-        $global:OutlookToken          = [PSCustomObject]@{ access_token = "fake" }
-        $global:MSTeamsToken          = [PSCustomObject]@{ access_token = "fake" }
-        $global:GraphToken            = [PSCustomObject]@{ access_token = "fake" }
-        $global:AzureCoreManagementToken = [PSCustomObject]@{ access_token = "fake" }
-        $global:OfficeManagementToken = [PSCustomObject]@{ access_token = "fake" }
-        $global:MSGraphToken          = [PSCustomObject]@{ access_token = "fake" }
-        $global:DODMSGraphToken       = [PSCustomObject]@{ access_token = "fake" }
-        $global:CustomToken           = [PSCustomObject]@{ access_token = "fake" }
-        $global:SubstrateToken        = [PSCustomObject]@{ access_token = "fake" }
-        $global:SharePointToken       = [PSCustomObject]@{ access_token = "fake" }
-        $global:YammerToken           = [PSCustomObject]@{ access_token = "fake" }
-        $global:DeviceRegistrationToken = [PSCustomObject]@{ access_token = "fake" }
+        foreach ($name in $script:TokenVariables) {
+            Set-Variable -Scope Global -Name $name -Value ([PSCustomObject]@{ access_token = $name })
+        }
     }
 
     AfterEach {
-        # Clean up any remaining global variables
-        Remove-Variable -Scope Global -Name response              -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name OutlookToken          -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name MSTeamsToken          -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name GraphToken            -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name AzureCoreManagementToken -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name OfficeManagementToken -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name MSGraphToken          -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name DODMSGraphToken       -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name CustomToken           -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name SubstrateToken        -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name SharePointToken       -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name YammerToken           -ErrorAction SilentlyContinue
-        Remove-Variable -Scope Global -Name DeviceRegistrationToken -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name $script:TokenVariables -ErrorAction SilentlyContinue
     }
 
-    Context "Clear-Token -Token All" {
-        It "Removes the `$response global variable" {
-            Clear-Token -Token All
-            { Get-Variable -Scope Global -Name response -ErrorAction Stop } | Should -Throw
-        }
+    It 'removes every token variable for -Token All' {
+        Clear-Token -Token All
 
-        It "Removes the `$MSTeamsToken global variable" {
-            Clear-Token -Token All
-            { Get-Variable -Scope Global -Name MSTeamsToken -ErrorAction Stop } | Should -Throw
-        }
-
-        It "Removes the `$MSGraphToken global variable" {
-            Clear-Token -Token All
-            { Get-Variable -Scope Global -Name MSGraphToken -ErrorAction Stop } | Should -Throw
-        }
-
-        It "Removes the `$SubstrateToken global variable" {
-            Clear-Token -Token All
-            { Get-Variable -Scope Global -Name SubstrateToken -ErrorAction Stop } | Should -Throw
+        foreach ($name in $script:TokenVariables) {
+            Get-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
         }
     }
 
-    Context "Clear-Token -Token specific" {
-        It "Removes only `$MSTeamsToken when -Token MSTeams is specified" {
-            Clear-Token -Token MSTeams
-            { Get-Variable -Scope Global -Name MSTeamsToken -ErrorAction Stop } | Should -Throw
-            # Other tokens should still exist
-            $global:response | Should -Not -BeNullOrEmpty
-        }
+    It 'removes <Variable> and no other variable for -Token <Token>' -ForEach $tokenCases {
+        Clear-Token -Token $Token
 
-        It "Removes only `$response when -Token Response is specified" {
-            Clear-Token -Token Response
-            { Get-Variable -Scope Global -Name response -ErrorAction Stop } | Should -Throw
-            $global:MSTeamsToken | Should -Not -BeNullOrEmpty
+        Get-Variable -Scope Global -Name $Variable -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+        foreach ($otherName in $script:TokenVariables | Where-Object { $_ -ne $Variable }) {
+            (Get-Variable -Scope Global -Name $otherName -ErrorAction Stop).Value.access_token | Should -Be $otherName
         }
+    }
 
-        It "Removes only `$MSGraphToken when -Token MSGraph is specified" {
-            Clear-Token -Token MSGraph
-            { Get-Variable -Scope Global -Name MSGraphToken -ErrorAction Stop } | Should -Throw
-            $global:response | Should -Not -BeNullOrEmpty
-        }
-
-        It "Removes only `$OutlookToken when -Token Outlook is specified" {
-            Clear-Token -Token Outlook
-            { Get-Variable -Scope Global -Name OutlookToken -ErrorAction Stop } | Should -Throw
-            $global:response | Should -Not -BeNullOrEmpty
-        }
-
-        It "Removes only `$GraphToken when -Token Graph is specified" {
-            Clear-Token -Token Graph
-            { Get-Variable -Scope Global -Name GraphToken -ErrorAction Stop } | Should -Throw
-            $global:response | Should -Not -BeNullOrEmpty
-        }
-
-        It "Removes only `$SharePointToken when -Token SharePoint is specified" {
-            Clear-Token -Token SharePoint
-            { Get-Variable -Scope Global -Name SharePointToken -ErrorAction Stop } | Should -Throw
-            $global:response | Should -Not -BeNullOrEmpty
-        }
-
-        It "Does not throw when the variable does not already exist" {
-            Remove-Variable -Scope Global -Name MSTeamsToken -ErrorAction SilentlyContinue
-            { Clear-Token -Token MSTeams } | Should -Not -Throw
-        }
+    It 'does not throw when the selected variable does not exist' {
+        Remove-Variable -Scope Global -Name MSTeamsToken -ErrorAction SilentlyContinue
+        { Clear-Token -Token MSTeams } | Should -Not -Throw
     }
 }

--- a/tests/CodeVerifier.Tests.ps1
+++ b/tests/CodeVerifier.Tests.ps1
@@ -9,6 +9,7 @@ Describe "CodeVerifier (PKCE helpers)" {
             InModuleScope TokenTactics {
                 $result = Get-TTCodeVerifier
                 $result | Should -Not -BeNullOrEmpty
+                $result.Length | Should -Be 43
             }
         }
 

--- a/tests/CodeVerifier.Tests.ps1
+++ b/tests/CodeVerifier.Tests.ps1
@@ -1,0 +1,72 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "CodeVerifier (PKCE helpers)" {
+    Context "Get-TTCodeVerifier" {
+        It "Returns a non-empty string" {
+            InModuleScope TokenTactics {
+                $result = Get-TTCodeVerifier
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It "Does not contain URL-unsafe characters" {
+            InModuleScope TokenTactics {
+                $result = Get-TTCodeVerifier
+                $result | Should -Not -Match '\+'
+                $result | Should -Not -Match '/'
+                $result | Should -Not -Match '='
+            }
+        }
+
+        It "Returns a different value on each call" {
+            InModuleScope TokenTactics {
+                $first  = Get-TTCodeVerifier
+                $second = Get-TTCodeVerifier
+                $first | Should -Not -Be $second
+            }
+        }
+    }
+
+    Context "Get-TTCodeChallenge" {
+        It "Returns a non-empty string" {
+            InModuleScope TokenTactics {
+                $verifier = Get-TTCodeVerifier
+                $result = Get-TTCodeChallenge -codeVerifier $verifier
+                $result | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It "Does not contain URL-unsafe characters" {
+            InModuleScope TokenTactics {
+                $verifier = Get-TTCodeVerifier
+                $result = Get-TTCodeChallenge -codeVerifier $verifier
+                $result | Should -Not -Match '\+'
+                $result | Should -Not -Match '/'
+                $result | Should -Not -Match '='
+            }
+        }
+
+        It "Produces the correct SHA-256 Base64URL challenge for a known verifier" {
+            InModuleScope TokenTactics {
+                # Known S256 challenge for verifier "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+                # SHA-256("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk") base64url = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+                $verifier  = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+                $expected  = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+                $result    = Get-TTCodeChallenge -codeVerifier $verifier
+                $result | Should -Be $expected
+            }
+        }
+
+        It "Returns the same challenge for the same verifier" {
+            InModuleScope TokenTactics {
+                $verifier = Get-TTCodeVerifier
+                $first  = Get-TTCodeChallenge -codeVerifier $verifier
+                $second = Get-TTCodeChallenge -codeVerifier $verifier
+                $first | Should -Be $second
+            }
+        }
+    }
+}

--- a/tests/ConvertFrom-JWTtoken.Tests.ps1
+++ b/tests/ConvertFrom-JWTtoken.Tests.ps1
@@ -28,8 +28,8 @@ Describe "ConvertFrom-JWTtoken" {
         It "Adds the IssuedAt computed property from iat" {
             $result = ConvertFrom-JWTtoken -token $script:TestJWT
             $result.IssuedAt | Should -BeOfType [DateTime]
-            # epoch 1700000000 = 2023-11-14T22:13:20Z
-            $result.IssuedAt.ToUniversalTime().Year | Should -Be 2023
+            $result.IssuedAt | Should -Be ([DateTime]::Parse('2023-11-14T22:13:20Z').ToUniversalTime())
+            $result.IssuedAt.Kind | Should -Be ([DateTimeKind]::Utc)
         }
 
         It "Adds the NotBefore computed property from nbf" {
@@ -40,6 +40,7 @@ Describe "ConvertFrom-JWTtoken" {
         It "Adds the ExpirationDate computed property from exp" {
             $result = ConvertFrom-JWTtoken -token $script:TestJWT
             $result.ExpirationDate | Should -BeOfType [DateTime]
+            $result.ExpirationDate | Should -Be ([DateTime]::Parse('2023-11-14T23:13:20Z').ToUniversalTime())
         }
 
         It "Adds the ValidForHours computed property (1 hour)" {
@@ -57,6 +58,33 @@ Describe "ConvertFrom-JWTtoken" {
             $result = $obj | ConvertFrom-JWTtoken
             $result.upn | Should -Be "test.user@contoso.com"
         }
+
+        It "decodes UTF-8 claims without data loss" {
+            $headerJson = '{"alg":"none","typ":"JWT"}'
+            $payloadJson = @{ name = 'Jorg: Jorg; Japanese: Tokyo'; iat = 0; exp = 3600 } | ConvertTo-Json -Compress
+            $payloadJson = $payloadJson.Replace('Jorg: Jorg; Japanese: Tokyo', "J$([char]0x00F6)rg $([char]0x6771)$([char]0x4EAC)")
+            $encode = {
+                param([string]$Value)
+                [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Value)).Replace('+', '-').Replace('/', '_').TrimEnd('=')
+            }
+            $token = "$(& $encode $headerJson).$(& $encode $payloadJson).signature"
+
+            $result = ConvertFrom-JWTtoken -Token $token
+
+            $result.name | Should -Be "J$([char]0x00F6)rg $([char]0x6771)$([char]0x4EAC)"
+            $result.IssuedAt | Should -Be ([DateTime]::UnixEpoch)
+            $result.ValidForHours | Should -Be 1
+        }
+
+        It "does not calculate ValidForHours when exp is absent" {
+            $header = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('{"alg":"none"}')).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+            $payload = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes('{"iat":1700000000}')).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+
+            $result = ConvertFrom-JWTtoken -Token "$header.$payload.signature"
+
+            $result.IssuedAt | Should -Not -BeNullOrEmpty
+            $result.PSObject.Properties.Name | Should -Not -Contain 'ValidForHours'
+        }
     }
 
     Context "Invalid token" {
@@ -66,6 +94,16 @@ Describe "ConvertFrom-JWTtoken" {
 
         It "Throws on a string that does not start with eyJ" {
             { ConvertFrom-JWTtoken -token "abc.def.ghi" } | Should -Throw
+        }
+
+        It "throws when the token has the wrong number of segments" {
+            { ConvertFrom-JWTtoken -Token 'eyJhbGciOiJub25lIn0.eyJzdWIiOiIxIn0' } | Should -Throw
+            { ConvertFrom-JWTtoken -Token 'eyJhbGciOiJub25lIn0.eyJzdWIiOiIxIn0.sig.extra' } | Should -Throw
+        }
+
+        It "throws for malformed Base64 or JSON" {
+            { ConvertFrom-JWTtoken -Token 'eyJ.invalid!.signature' } | Should -Throw
+            { ConvertFrom-JWTtoken -Token 'eyJub3QtanNvbg.e25vdC1qc29u.signature' } | Should -Throw
         }
     }
 }

--- a/tests/ConvertFrom-JWTtoken.Tests.ps1
+++ b/tests/ConvertFrom-JWTtoken.Tests.ps1
@@ -1,0 +1,71 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "ConvertFrom-JWTtoken" {
+    Context "Valid token" {
+        It "Decodes the upn claim" {
+            $result = ConvertFrom-JWTtoken -token $script:TestJWT
+            $result.upn | Should -Be "test.user@contoso.com"
+        }
+
+        It "Decodes the aud claim" {
+            $result = ConvertFrom-JWTtoken -token $script:TestJWT
+            $result.aud | Should -Be "https://graph.microsoft.com"
+        }
+
+        It "Decodes the tid claim" {
+            $result = ConvertFrom-JWTtoken -token $script:TestJWT
+            $result.tid | Should -Be "00000000-0000-0000-0000-000000000001"
+        }
+
+        It "Decodes the scp claim" {
+            $result = ConvertFrom-JWTtoken -token $script:TestJWT
+            $result.scp | Should -Be "User.Read"
+        }
+
+        It "Adds the IssuedAt computed property from iat" {
+            $result = ConvertFrom-JWTtoken -token $script:TestJWT
+            $result.IssuedAt | Should -BeOfType [DateTime]
+            # epoch 1700000000 = 2023-11-14T22:13:20Z
+            $result.IssuedAt.ToUniversalTime().Year | Should -Be 2023
+        }
+
+        It "Adds the NotBefore computed property from nbf" {
+            $result = ConvertFrom-JWTtoken -token $script:TestJWT
+            $result.NotBefore | Should -BeOfType [DateTime]
+        }
+
+        It "Adds the ExpirationDate computed property from exp" {
+            $result = ConvertFrom-JWTtoken -token $script:TestJWT
+            $result.ExpirationDate | Should -BeOfType [DateTime]
+        }
+
+        It "Adds the ValidForHours computed property (1 hour)" {
+            $result = ConvertFrom-JWTtoken -token $script:TestJWT
+            $result.ValidForHours | Should -Be 1.0
+        }
+
+        It "Accepts token via pipeline" {
+            $result = $script:TestJWT | ConvertFrom-JWTtoken
+            $result.upn | Should -Be "test.user@contoso.com"
+        }
+
+        It "Accepts token via -access_token alias" {
+            $obj = [PSCustomObject]@{ access_token = $script:TestJWT }
+            $result = $obj | ConvertFrom-JWTtoken
+            $result.upn | Should -Be "test.user@contoso.com"
+        }
+    }
+
+    Context "Invalid token" {
+        It "Throws on a string without dots" {
+            { ConvertFrom-JWTtoken -token "notavalidtoken" } | Should -Throw
+        }
+
+        It "Throws on a string that does not start with eyJ" {
+            { ConvertFrom-JWTtoken -token "abc.def.ghi" } | Should -Throw
+        }
+    }
+}

--- a/tests/ConvertTo-Base64Url.Tests.ps1
+++ b/tests/ConvertTo-Base64Url.Tests.ps1
@@ -1,0 +1,35 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "ConvertTo-Base64Url" {
+    It "Encodes a simple byte array without padding characters" {
+        $bytes = [System.Text.Encoding]::UTF8.GetBytes("hello")
+        InModuleScope TokenTactics {
+            $result = ConvertTo-Base64Url -Bytes ([System.Text.Encoding]::UTF8.GetBytes("hello"))
+            $result | Should -Not -Match '\+'
+            $result | Should -Not -Match '/'
+            $result | Should -Not -Match '='
+        }
+    }
+
+    It "Produces the expected Base64URL output for a known input" {
+        # "hello" in standard Base64 is "aGVsbG8=" -> Base64URL is "aGVsbG8"
+        InModuleScope TokenTactics {
+            $bytes = [System.Text.Encoding]::UTF8.GetBytes("hello")
+            $result = ConvertTo-Base64Url -Bytes $bytes
+            $result | Should -Be "aGVsbG8"
+        }
+    }
+
+    It "Replaces + with - and / with _ compared to standard Base64" {
+        # Byte sequence that produces + and / in standard Base64: bytes 0xFB, 0xFF (standard: +//x -> -__x in Base64URL)
+        InModuleScope TokenTactics {
+            $bytes = [byte[]](0xFB, 0xFF)
+            $standard = [Convert]::ToBase64String($bytes)  # "+/8="
+            $result = ConvertTo-Base64Url -Bytes $bytes
+            $result | Should -Be ($standard.Replace('+', '-').Replace('/', '_').TrimEnd('='))
+        }
+    }
+}

--- a/tests/ConvertTo-PEMPrivateKey.Tests.ps1
+++ b/tests/ConvertTo-PEMPrivateKey.Tests.ps1
@@ -1,0 +1,48 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "ConvertTo-PEMPrivateKey" {
+    Context "Input already in PEM format" {
+        It "Returns the input unchanged when it already has PEM headers" {
+            $pemKey = "-----BEGIN PRIVATE KEY-----`nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg`n-----END PRIVATE KEY-----"
+            $result = ConvertTo-PEMPrivateKey -PrivateKey $pemKey
+            $result | Should -Be $pemKey
+        }
+    }
+
+    Context "Raw Base64 key" {
+        It "Wraps the key with PEM BEGIN and END headers" {
+            $rawKey = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgtest1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+            $result = ConvertTo-PEMPrivateKey -PrivateKey $rawKey
+            $result | Should -Match "^-----BEGIN PRIVATE KEY-----"
+            $result | Should -Match "-----END PRIVATE KEY-----$"
+        }
+
+        It "Wraps lines at 64 characters" {
+            $rawKey = "A" * 128  # 128 chars -> 2 lines of 64
+            $result = ConvertTo-PEMPrivateKey -PrivateKey $rawKey
+            $lines = $result -split "`n"
+            # Lines between BEGIN and END should each be <= 64 characters
+            $contentLines = $lines | Where-Object { $_ -notmatch "-----" -and $_.Length -gt 0 }
+            $contentLines | ForEach-Object { $_.Length | Should -BeLessOrEqual 64 }
+        }
+
+        It "Replaces dashes with plus and underscores with slash" {
+            # Input with URL-safe Base64 characters (- -> +, _ -> /)
+            $rawKey = "AAAA-AAAA_AAAA"
+            $result = ConvertTo-PEMPrivateKey -PrivateKey $rawKey
+            # Only check the content lines (skip PEM header/footer lines)
+            $contentLines = ($result -split "`n") | Where-Object { $_ -notmatch "^-----" -and $_.Trim() -ne "" }
+            $contentLines | ForEach-Object { $_ | Should -Not -Match "-" }
+            $contentLines | ForEach-Object { $_ | Should -Not -Match "_" }
+        }
+
+        It "Accepts input from pipeline" {
+            $rawKey = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgABCDEFGH"
+            $result = $rawKey | ConvertTo-PEMPrivateKey
+            $result | Should -Match "-----BEGIN PRIVATE KEY-----"
+        }
+    }
+}

--- a/tests/ConvertTo-PEMPrivateKey.Tests.ps1
+++ b/tests/ConvertTo-PEMPrivateKey.Tests.ps1
@@ -1,48 +1,54 @@
 BeforeAll {
     . "$PSScriptRoot/fixtures/TestData.ps1"
     Import-Module $script:ModulePath -Force
+
+    $curve = [System.Security.Cryptography.ECCurve]::CreateFromFriendlyName('nistP256')
+    $script:Ecdsa = [System.Security.Cryptography.ECDsa]::Create($curve)
+    $script:Pkcs8Bytes = $script:Ecdsa.ExportPkcs8PrivateKey()
+    $script:RawBase64 = [Convert]::ToBase64String($script:Pkcs8Bytes)
+    $script:RawBase64Url = $script:RawBase64.Replace('+', '-').Replace('/', '_').TrimEnd('=')
 }
 
-Describe "ConvertTo-PEMPrivateKey" {
-    Context "Input already in PEM format" {
-        It "Returns the input unchanged when it already has PEM headers" {
-            $pemKey = "-----BEGIN PRIVATE KEY-----`nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg`n-----END PRIVATE KEY-----"
-            $result = ConvertTo-PEMPrivateKey -PrivateKey $pemKey
-            $result | Should -Be $pemKey
+AfterAll {
+    if ($script:Ecdsa) {
+        $script:Ecdsa.Dispose()
+    }
+}
+
+Describe 'ConvertTo-PEMPrivateKey' {
+    It 'returns an existing PEM value unchanged' {
+        $pem = -join [System.Security.Cryptography.PemEncoding]::Write('PRIVATE KEY', $script:Pkcs8Bytes)
+        ConvertTo-PEMPrivateKey -PrivateKey $pem | Should -BeExactly $pem
+    }
+
+    It 'converts unpadded Base64URL PKCS#8 data into importable PEM' {
+        $pem = ConvertTo-PEMPrivateKey -PrivateKey $script:RawBase64Url
+        $imported = [System.Security.Cryptography.ECDsa]::Create()
+        try {
+            $imported.ImportFromPem($pem)
+            $data = [Text.Encoding]::UTF8.GetBytes('TokenTactics test')
+            $signature = $imported.SignData($data, [Security.Cryptography.HashAlgorithmName]::SHA256)
+            $script:Ecdsa.VerifyData($data, $signature, [Security.Cryptography.HashAlgorithmName]::SHA256) | Should -BeTrue
+        } finally {
+            $imported.Dispose()
         }
     }
 
-    Context "Raw Base64 key" {
-        It "Wraps the key with PEM BEGIN and END headers" {
-            $rawKey = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgtest1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
-            $result = ConvertTo-PEMPrivateKey -PrivateKey $rawKey
-            $result | Should -Match "^-----BEGIN PRIVATE KEY-----"
-            $result | Should -Match "-----END PRIVATE KEY-----$"
-        }
+    It 'wraps content lines at no more than 64 characters' {
+        $pem = ConvertTo-PEMPrivateKey -PrivateKey $script:RawBase64
+        $contentLines = $pem -split "`n" | Where-Object { $_ -notmatch '^-----' -and $_ }
 
-        It "Wraps lines at 64 characters" {
-            $rawKey = "A" * 128  # 128 chars -> 2 lines of 64
-            $result = ConvertTo-PEMPrivateKey -PrivateKey $rawKey
-            $lines = $result -split "`n"
-            # Lines between BEGIN and END should each be <= 64 characters
-            $contentLines = $lines | Where-Object { $_ -notmatch "-----" -and $_.Length -gt 0 }
-            $contentLines | ForEach-Object { $_.Length | Should -BeLessOrEqual 64 }
-        }
+        $contentLines.Count | Should -BeGreaterThan 1
+        $contentLines | ForEach-Object { $_.Length | Should -BeLessOrEqual 64 }
+    }
 
-        It "Replaces dashes with plus and underscores with slash" {
-            # Input with URL-safe Base64 characters (- -> +, _ -> /)
-            $rawKey = "AAAA-AAAA_AAAA"
-            $result = ConvertTo-PEMPrivateKey -PrivateKey $rawKey
-            # Only check the content lines (skip PEM header/footer lines)
-            $contentLines = ($result -split "`n") | Where-Object { $_ -notmatch "^-----" -and $_.Trim() -ne "" }
-            $contentLines | ForEach-Object { $_ | Should -Not -Match "-" }
-            $contentLines | ForEach-Object { $_ | Should -Not -Match "_" }
-        }
+    It 'accepts valid key data from the pipeline' {
+        $pem = $script:RawBase64Url | ConvertTo-PEMPrivateKey
+        $pem | Should -Match '^-----BEGIN PRIVATE KEY-----'
+        $pem | Should -Match '-----END PRIVATE KEY-----$'
+    }
 
-        It "Accepts input from pipeline" {
-            $rawKey = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgABCDEFGH"
-            $result = $rawKey | ConvertTo-PEMPrivateKey
-            $result | Should -Match "-----BEGIN PRIVATE KEY-----"
-        }
+    It 'rejects malformed Base64 data' {
+        { ConvertTo-PEMPrivateKey -PrivateKey 'not-a-private-key!' } | Should -Throw '*valid Base64*'
     }
 }

--- a/tests/ConvertTo-URLParameters.Tests.ps1
+++ b/tests/ConvertTo-URLParameters.Tests.ps1
@@ -30,6 +30,25 @@ Describe "ConvertTo-URLParameters" {
         InModuleScope TokenTactics {
             $result = ConvertTo-URLParameters -RequestURL "https://example.com/callback"
             $result | Should -BeOfType [hashtable]
+            $result.Count | Should -Be 0
+        }
+    }
+
+    It "URL-decodes names and values without corrupting embedded equals signs" {
+        InModuleScope TokenTactics {
+            $result = ConvertTo-URLParameters -RequestURL "https://example.com/callback?authorization%20code=abc%2Bdef%2Fghi%3D%3D&state=a=b=c"
+            $result['authorization code'] | Should -Be 'abc+def/ghi=='
+            $result['state'] | Should -Be 'a=b=c'
+        }
+    }
+
+    It "handles empty values, parameters without equals signs, and fragments" {
+        InModuleScope TokenTactics {
+            $result = ConvertTo-URLParameters -RequestURL "https://example.com/callback?empty=&flag&code=value#ignored=true"
+            $result.Count | Should -Be 3
+            $result['empty'] | Should -Be ''
+            $result['flag'] | Should -Be ''
+            $result['code'] | Should -Be 'value'
         }
     }
 }

--- a/tests/ConvertTo-URLParameters.Tests.ps1
+++ b/tests/ConvertTo-URLParameters.Tests.ps1
@@ -1,0 +1,35 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "ConvertTo-URLParameters" {
+    It "Parses a simple query string into a hashtable" {
+        InModuleScope TokenTactics {
+            $result = ConvertTo-URLParameters -RequestURL "https://example.com/callback?code=abc123&state=xyz"
+            $result['code'] | Should -Be "abc123"
+            $result['state'] | Should -Be "xyz"
+        }
+    }
+
+    It "Returns a hashtable with correct key count" {
+        InModuleScope TokenTactics {
+            $result = ConvertTo-URLParameters -RequestURL "https://example.com/callback?code=abc&state=def&session_state=ghi"
+            $result.Count | Should -Be 3
+        }
+    }
+
+    It "Handles a URL with a single parameter" {
+        InModuleScope TokenTactics {
+            $result = ConvertTo-URLParameters -RequestURL "https://example.com/callback?code=singlecode"
+            $result['code'] | Should -Be "singlecode"
+        }
+    }
+
+    It "Returns an empty hashtable for a URL with no query string" {
+        InModuleScope TokenTactics {
+            $result = ConvertTo-URLParameters -RequestURL "https://example.com/callback"
+            $result | Should -BeOfType [hashtable]
+        }
+    }
+}

--- a/tests/Fido.Tests.ps1
+++ b/tests/Fido.Tests.ps1
@@ -1,0 +1,142 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+
+    $curve = [System.Security.Cryptography.ECCurve]::CreateFromFriendlyName('nistP256')
+    $script:Ecdsa = [System.Security.Cryptography.ECDsa]::Create($curve)
+    $script:PrivateKeyPem = -join [System.Security.Cryptography.PemEncoding]::Write('PRIVATE KEY', $script:Ecdsa.ExportPkcs8PrivateKey())
+}
+
+AfterAll {
+    if ($script:Ecdsa) {
+        $script:Ecdsa.Dispose()
+    }
+    Remove-Variable -Scope Global -Name ESTSAUTH, webSession -ErrorAction SilentlyContinue
+}
+
+Describe 'FIDO cryptographic helpers' {
+    It 'constructs the exact 37-byte authenticator data layout' {
+        $result = InModuleScope TokenTactics {
+            New-FidoAuthenticatorData -RpId 'login.microsoft.com' -SignCount 0x01020304 -Flags 0x05
+        }
+        $expectedHash = [System.Security.Cryptography.SHA256]::HashData([Text.Encoding]::UTF8.GetBytes('login.microsoft.com'))
+
+        $result.Count | Should -Be 37
+        [Convert]::ToHexString($result[0..31]) | Should -Be ([Convert]::ToHexString($expectedHash))
+        $result[32] | Should -Be 0x05
+        $result[33..36] | Should -Be ([byte[]](0x01, 0x02, 0x03, 0x04))
+    }
+
+    It 'creates WebAuthn client data and a verifiable DER ECDSA signature' {
+        $authData = InModuleScope TokenTactics {
+            New-FidoAuthenticatorData -RpId 'login.microsoft.com' -SignCount 7
+        }
+        $result = InModuleScope TokenTactics -Parameters @{
+            AuthData = $authData
+            KeyPem   = $script:PrivateKeyPem
+        } {
+            param($AuthData, $KeyPem)
+            New-FidoSignature -Challenge 'server-challenge_123' -Origin 'https://login.microsoft.com' -AuthDataBytes $AuthData -PrivateKeyPem $KeyPem
+        }
+
+        $clientData = [Text.Encoding]::UTF8.GetString($result.ClientData) | ConvertFrom-Json
+        $clientData.type | Should -Be 'webauthn.get'
+        $clientData.challenge | Should -Be 'server-challenge_123'
+        $clientData.origin | Should -Be 'https://login.microsoft.com'
+        $clientData.crossOrigin | Should -BeFalse
+
+        $clientHash = [System.Security.Cryptography.SHA256]::HashData($result.ClientData)
+        $signedData = [byte[]]($authData + $clientHash)
+        $script:Ecdsa.VerifyData(
+            $signedData,
+            $result.Signature,
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.DSASignatureFormat]::Rfc3279DerSequence
+        ) | Should -BeTrue
+    }
+}
+
+Describe 'Invoke-EntraIDPasskeyLogin' {
+    BeforeEach {
+        $script:ServerChallenge = 'already-base64url_challenge'
+        $sessionInformation = @{
+            sFidoChallenge     = $script:ServerChallenge
+            sFT                = 'flow-token'
+            sCtx               = 'context'
+            canary             = 'canary'
+            correlationId      = 'correlation'
+            urlPost            = '/post'
+            urlPostAad         = '/post-aad'
+            urlPostMsa         = '/post-msa'
+            urlRefresh         = '/refresh'
+            urlResume          = '/resume'
+            oGetCredTypeResult = @{
+                FlowToken  = 'credential-flow-token'
+                Credentials = @{
+                    HasFido    = $true
+                    FidoParams = @{ AllowList = @('credential') }
+                }
+            }
+        } | ConvertTo-Json -Compress -Depth 10
+        $responseInformation = @{
+            sCrossDomainCanary = 'cross-domain-canary'
+            sessionId          = 'session-id'
+            sCtx               = 'response-context'
+            canary             = 'response-canary'
+            sFT                = 'response-flow-token'
+        } | ConvertTo-Json -Compress
+
+        Mock -ModuleName TokenTactics ConvertTo-PEMPrivateKey { 'valid-pem' }
+        Mock -ModuleName TokenTactics New-FidoAuthenticatorData { [byte[]](0..36) }
+        Mock -ModuleName TokenTactics New-FidoSignature {
+            [PSCustomObject]@{
+                ClientData = [Text.Encoding]::UTF8.GetBytes('{}')
+                Signature  = [byte[]](1, 2, 3)
+            }
+        }
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            param($Uri)
+            if ($Uri -match '/organizations/oauth2/v2\.0/authorize') {
+                return [PSCustomObject]@{ Content = $sessionInformation; StatusCode = 200 }
+            }
+            if ($Uri -eq 'https://login.microsoft.com/common/fido/get?uiflavor=Web') {
+                return [PSCustomObject]@{ Content = $responseInformation; StatusCode = 200 }
+            }
+            return [PSCustomObject]@{ Content = '{}'; StatusCode = 200; Error = $null }
+        }
+    }
+
+    It 'passes the server challenge through unchanged and uses normalized assertion values' {
+        $credentialId = '00112233-4455-6677-8899-aabbccddeeff'
+        $credentialBytes = [Convert]::FromHexString($credentialId.Replace('-', ''))
+        $expectedCredentialId = [Convert]::ToBase64String($credentialBytes).Replace('+', '-').Replace('/', '_').TrimEnd('=')
+
+        Invoke-EntraIDPasskeyLogin -UserPrincipalName 'user@contoso.com' -UserHandle 'user-handle' -CredentialId $credentialId -PrivateKey 'raw-key'
+
+        Should -Invoke -ModuleName TokenTactics New-FidoSignature -Times 1 -Exactly -Scope It -ParameterFilter {
+            $Challenge -eq 'already-base64url_challenge' -and
+            $Origin -eq 'https://login.microsoft.com' -and
+            $PrivateKeyPem -eq 'valid-pem'
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1 -Exactly -Scope It -ParameterFilter {
+            if ($Uri -ne 'https://login.microsoftonline.com/common/login') {
+                return $false
+            }
+            $assertion = $Body.assertion | ConvertFrom-Json
+            $assertion.id -eq $expectedCredentialId -and $assertion.userHandle -eq 'user-handle'
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1 -Exactly -Scope It -ParameterFilter {
+            $Uri -eq 'https://login.microsoftonline.com/common/login?sso_reload=true' -and
+            $Body.lmcCanary -eq 'cross-domain-canary' -and
+            $Body.hpgrequestid -eq 'session-id' -and
+            $Body.ctx -eq 'context' -and
+            $Body.canary -eq 'canary' -and
+            $Body.flowToken -eq 'credential-flow-token'
+        }
+    }
+
+    It 'throws instead of terminating the PowerShell host when the key file is missing' {
+        { Invoke-EntraIDPasskeyLogin -KeyFilePath (Join-Path $TestDrive 'missing.json') } | Should -Throw '*not found*'
+        Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 0 -Exactly -Scope It
+    }
+}

--- a/tests/Fido.Tests.ps1
+++ b/tests/Fido.Tests.ps1
@@ -58,7 +58,7 @@ Describe 'FIDO cryptographic helpers' {
 
 Describe 'Invoke-EntraIDPasskeyLogin' {
     BeforeEach {
-        $script:ServerChallenge = 'already-base64url_challenge'
+        $script:ServerChallenge = 'server-challenge-value'
         $sessionInformation = @{
             sFidoChallenge     = $script:ServerChallenge
             sFT                = 'flow-token'
@@ -106,15 +106,16 @@ Describe 'Invoke-EntraIDPasskeyLogin' {
         }
     }
 
-    It 'passes the server challenge through unchanged and uses normalized assertion values' {
+    It 'Base64URL-encodes the server challenge bytes and uses normalized assertion values' {
         $credentialId = '00112233-4455-6677-8899-aabbccddeeff'
         $credentialBytes = [Convert]::FromHexString($credentialId.Replace('-', ''))
         $expectedCredentialId = [Convert]::ToBase64String($credentialBytes).Replace('+', '-').Replace('/', '_').TrimEnd('=')
+        $expectedChallenge = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($script:ServerChallenge)).Replace('+', '-').Replace('/', '_').TrimEnd('=')
 
         Invoke-EntraIDPasskeyLogin -UserPrincipalName 'user@contoso.com' -UserHandle 'user-handle' -CredentialId $credentialId -PrivateKey 'raw-key'
 
         Should -Invoke -ModuleName TokenTactics New-FidoSignature -Times 1 -Exactly -Scope It -ParameterFilter {
-            $Challenge -eq 'already-base64url_challenge' -and
+            $Challenge -eq $expectedChallenge -and
             $Origin -eq 'https://login.microsoft.com' -and
             $PrivateKeyPem -eq 'valid-pem'
         }

--- a/tests/Get-EntraIDTokenFromSCCAUTHCookie.Tests.ps1
+++ b/tests/Get-EntraIDTokenFromSCCAUTHCookie.Tests.ps1
@@ -1,0 +1,117 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+
+    $script:FakeSCCAuth = "fakeSCCauthcookie"
+    $script:FakeXSRF    = "fakeXSRFtoken"
+
+    # Fake token response returned by the XDR API
+    $script:FakeXdrToken = [PSCustomObject]@{
+        token     = "eyFakeAccessToken"
+        tokenType = "Bearer"
+    }
+}
+
+Describe "Get-EntraIDTokenFromSCCAUTHCookie" {
+    Context "XSRF provided by caller" {
+        BeforeAll {
+            Mock -ModuleName TokenTactics Invoke-WebRequest {} # not called when XSRF is supplied
+            Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeXdrToken }
+        }
+
+        It "Does not call Invoke-WebRequest when XSRF is provided" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftGraph"
+            Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 0
+        }
+
+        It "Calls the token endpoint and returns the response" {
+            $result = Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftGraph"
+            $result | Should -Not -BeNullOrEmpty
+        }
+
+        It "Uses the MicrosoftGraph resource URL" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftGraph"
+            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+                $Uri -match "graph\.microsoft\.com"
+            } -Times 1
+        }
+
+        It "Uses the Azure resource URL for ResourceName Azure" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "Azure"
+            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+                $Uri -match "management\.core\.windows\.net"
+            } -Times 1
+        }
+
+        It "Uses the LogAnalytics resource GUID" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "LogAnalytics"
+            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+                $Uri -match "ca7f3f0b"
+            } -Times 1
+        }
+
+        It "Uses the MicrosoftOffice resource URL" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftOffice"
+            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+                $Uri -match "portal\.office\.com"
+            } -Times 1
+        }
+
+        It "Uses a custom resource URL when -Resource is specified" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -Resource "https://custom.example.com/"
+            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+                $Uri -match "custom\.example\.com"
+            } -Times 1
+        }
+
+        It "Includes the serviceType query parameter when it is set (Purview)" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "Purview"
+            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+                $Uri -match "serviceType=73c2949e"
+            } -Times 1
+        }
+
+        It "Sets the X-XSRF-TOKEN request header" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftGraph"
+            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+                $Headers -is [hashtable] -and $Headers.ContainsKey("X-XSRF-TOKEN")
+            } -Times 1
+        }
+    }
+
+    Context "XSRF obtained automatically" {
+        BeforeAll {
+            # Simulate Invoke-WebRequest adding an xsrf-token cookie to the session
+            Mock -ModuleName TokenTactics Invoke-WebRequest {
+                param($WebSession, $Uri)
+                $cookie = [System.Net.Cookie]::new("xsrf-token", $script:FakeXSRF, "/", "security.microsoft.com")
+                $WebSession.Cookies.Add([Uri]"https://security.microsoft.com/", $cookie)
+                return [PSCustomObject]@{ StatusCode = 200 }
+            }
+            Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeXdrToken }
+        }
+
+        It "Calls Invoke-WebRequest to obtain the XSRF token" {
+            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -ResourceName "MicrosoftGraph"
+            Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1
+        }
+
+        It "Calls the token endpoint after obtaining XSRF automatically" {
+            $result = Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -ResourceName "MicrosoftGraph"
+            $result | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context "XSRF cookie not returned (failure path)" {
+        BeforeAll {
+            # Simulate Invoke-WebRequest NOT adding the xsrf-token cookie
+            Mock -ModuleName TokenTactics Invoke-WebRequest {
+                return [PSCustomObject]@{ StatusCode = 200 }
+            }
+        }
+
+        It "Throws when XSRF cookie cannot be obtained" {
+            { Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -ResourceName "MicrosoftGraph" } | Should -Throw
+        }
+    }
+}

--- a/tests/Get-EntraIDTokenFromSCCAUTHCookie.Tests.ps1
+++ b/tests/Get-EntraIDTokenFromSCCAUTHCookie.Tests.ps1
@@ -1,117 +1,145 @@
+$resourceCases = @(
+    @{ ResourceName = 'Azure'; Resource = 'https://management.core.windows.net/'; ServiceType = $null }
+    @{ ResourceName = 'LogAnalytics'; Resource = 'ca7f3f0b-7d91-482c-8e09-c5d840d0eac5'; ServiceType = $null }
+    @{ ResourceName = 'MATP'; Resource = 'MATP'; ServiceType = $null }
+    @{ ResourceName = 'MCAS'; Resource = 'MCAS'; ServiceType = $null }
+    @{ ResourceName = 'MicrosoftGraph'; Resource = 'https://graph.microsoft.com/'; ServiceType = $null }
+    @{ ResourceName = 'MicrosoftOffice'; Resource = 'https://portal.office.com'; ServiceType = $null }
+    @{ ResourceName = 'Purview'; Resource = 'https://api.purview-service.microsoft.com'; ServiceType = '73c2949e-da2d-457a-9607-fcc665198967' }
+    @{ ResourceName = 'ThreatIntelligencePortal'; Resource = '478d8d1a-326f-49da-a58e-8f576faa4b5e'; ServiceType = $null }
+)
+
 BeforeAll {
     . "$PSScriptRoot/fixtures/TestData.ps1"
     Import-Module $script:ModulePath -Force
 
-    $script:FakeSCCAuth = "fakeSCCauthcookie"
-    $script:FakeXSRF    = "fakeXSRFtoken"
-
-    # Fake token response returned by the XDR API
-    $script:FakeXdrToken = [PSCustomObject]@{
-        token     = "eyFakeAccessToken"
-        tokenType = "Bearer"
-    }
+    $script:FakeSCCAuth = 'fake-sccauth-cookie'
+    $script:FakeXSRF = 'fake%2Bxsrf%2Ftoken'
+    $script:DecodedXSRF = 'fake+xsrf/token'
+    $script:FakeXdrToken = [PSCustomObject]@{ token = 'fake-access-token'; tokenType = 'Bearer' }
 }
 
-Describe "Get-EntraIDTokenFromSCCAUTHCookie" {
-    Context "XSRF provided by caller" {
-        BeforeAll {
-            Mock -ModuleName TokenTactics Invoke-WebRequest {} # not called when XSRF is supplied
-            Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeXdrToken }
-        }
+Describe 'Get-EntraIDTokenFromSCCAUTHCookie' {
+    BeforeEach {
+        Mock -ModuleName TokenTactics Invoke-WebRequest { throw 'Unexpected bootstrap request' }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $script:FakeXdrToken }
+    }
 
-        It "Does not call Invoke-WebRequest when XSRF is provided" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftGraph"
-            Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 0
-        }
+    It 'maps <ResourceName> to the exact XDR token request' -ForEach $resourceCases {
+        $result = Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName $ResourceName
 
-        It "Calls the token endpoint and returns the response" {
-            $result = Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftGraph"
-            $result | Should -Not -BeNullOrEmpty
-        }
-
-        It "Uses the MicrosoftGraph resource URL" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftGraph"
-            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
-                $Uri -match "graph\.microsoft\.com"
-            } -Times 1
-        }
-
-        It "Uses the Azure resource URL for ResourceName Azure" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "Azure"
-            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
-                $Uri -match "management\.core\.windows\.net"
-            } -Times 1
-        }
-
-        It "Uses the LogAnalytics resource GUID" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "LogAnalytics"
-            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
-                $Uri -match "ca7f3f0b"
-            } -Times 1
-        }
-
-        It "Uses the MicrosoftOffice resource URL" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftOffice"
-            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
-                $Uri -match "portal\.office\.com"
-            } -Times 1
-        }
-
-        It "Uses a custom resource URL when -Resource is specified" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -Resource "https://custom.example.com/"
-            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
-                $Uri -match "custom\.example\.com"
-            } -Times 1
-        }
-
-        It "Includes the serviceType query parameter when it is set (Purview)" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "Purview"
-            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
-                $Uri -match "serviceType=73c2949e"
-            } -Times 1
-        }
-
-        It "Sets the X-XSRF-TOKEN request header" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName "MicrosoftGraph"
-            Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
-                $Headers -is [hashtable] -and $Headers.ContainsKey("X-XSRF-TOKEN")
-            } -Times 1
+        $result | Should -Be $script:FakeXdrToken
+        Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 0 -Exactly -Scope It
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+            $parsedUri = [Uri]$Uri
+            $query = [System.Web.HttpUtility]::ParseQueryString($parsedUri.Query)
+            $parsedUri.Scheme -eq 'https' -and
+            $parsedUri.Host -eq 'security.microsoft.com' -and
+            $parsedUri.AbsolutePath -eq '/api/Auth/getToken' -and
+            $query['resource'] -eq $Resource -and
+            $query['serviceType'] -eq $ServiceType -and
+            $ContentType -eq 'application/json' -and
+            $WebSession -is [Microsoft.PowerShell.Commands.WebRequestSession] -and
+            $Headers.Count -eq 1 -and
+            $Headers['X-XSRF-TOKEN'] -eq 'fake+xsrf/token'
         }
     }
 
-    Context "XSRF obtained automatically" {
-        BeforeAll {
-            # Simulate Invoke-WebRequest adding an xsrf-token cookie to the session
-            Mock -ModuleName TokenTactics Invoke-WebRequest {
-                param($WebSession, $Uri)
-                $cookie = [System.Net.Cookie]::new("xsrf-token", $script:FakeXSRF, "/", "security.microsoft.com")
-                $WebSession.Cookies.Add([Uri]"https://security.microsoft.com/", $cookie)
-                return [PSCustomObject]@{ StatusCode = 200 }
-            }
-            Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeXdrToken }
-        }
+    It 'uses exact custom resource, service type, tenant headers, and decoded XSRF value' {
+        Get-EntraIDTokenFromSCCAUTHCookie `
+            -SCCAuth $script:FakeSCCAuth `
+            -XSRF $script:FakeXSRF `
+            -Resource 'api://custom-resource' `
+            -ServiceType 'custom-service' `
+            -TenantId 'tenant-id'
 
-        It "Calls Invoke-WebRequest to obtain the XSRF token" {
-            Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -ResourceName "MicrosoftGraph"
-            Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1
-        }
-
-        It "Calls the token endpoint after obtaining XSRF automatically" {
-            $result = Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -ResourceName "MicrosoftGraph"
-            $result | Should -Not -BeNullOrEmpty
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+            $parsedUri = [Uri]$Uri
+            $query = [System.Web.HttpUtility]::ParseQueryString($parsedUri.Query)
+            $query['resource'] -eq 'api://custom-resource' -and
+            $query['serviceType'] -eq 'custom-service' -and
+            $Headers.Count -eq 3 -and
+            $Headers['X-XSRF-TOKEN'] -eq 'fake+xsrf/token' -and
+            $Headers['x-tid'] -eq 'tenant-id' -and
+            $Headers['tenant-id'] -eq 'tenant-id'
         }
     }
 
-    Context "XSRF cookie not returned (failure path)" {
-        BeforeAll {
-            # Simulate Invoke-WebRequest NOT adding the xsrf-token cookie
-            Mock -ModuleName TokenTactics Invoke-WebRequest {
-                return [PSCustomObject]@{ StatusCode = 200 }
-            }
+    It 'constructs the PurviewACC resource from an explicitly supplied tenant' {
+        Get-EntraIDTokenFromSCCAUTHCookie `
+            -SCCAuth $script:FakeSCCAuth `
+            -XSRF $script:FakeXSRF `
+            -ResourceName PurviewACC `
+            -TenantId 'tenant-id'
+
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+            $query = [System.Web.HttpUtility]::ParseQueryString(([Uri]$Uri).Query)
+            $query['resource'] -eq 'https://tenant-id-api.purview-service.microsoft.com' -and
+            $query['serviceType'] -eq '73c2949e-da2d-457a-9607-fcc665198967' -and
+            $Headers['x-tid'] -eq 'tenant-id' -and
+            $Headers['tenant-id'] -eq 'tenant-id'
+        }
+    }
+
+    It 'retrieves the tenant before requesting a PurviewACC token when none is supplied' {
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw "Unexpected REST request: $Uri" }
+        Mock -ModuleName TokenTactics Invoke-RestMethod {
+            [PSCustomObject]@{ AuthInfo = [PSCustomObject]@{ TenantId = 'discovered-tenant' } }
+        } -ParameterFilter { $Uri -match '/TenantContext\?realTime=true$' }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $script:FakeXdrToken } -ParameterFilter {
+            $query = [System.Web.HttpUtility]::ParseQueryString(([Uri]$Uri).Query)
+            $query['resource'] -eq 'https://discovered-tenant-api.purview-service.microsoft.com'
         }
 
-        It "Throws when XSRF cookie cannot be obtained" {
-            { Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -ResourceName "MicrosoftGraph" } | Should -Throw
+        $result = Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName PurviewACC
+
+        $result | Should -Be $script:FakeXdrToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 2 -Exactly -Scope It
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+            $Uri -eq 'https://security.microsoft.com/apiproxy/mtp/sccManagement/mgmt/TenantContext?realTime=true'
         }
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+            $query = [System.Web.HttpUtility]::ParseQueryString(([Uri]$Uri).Query)
+            $query['resource'] -eq 'https://discovered-tenant-api.purview-service.microsoft.com' -and
+            $Headers['x-tid'] -eq 'discovered-tenant' -and
+            $Headers['tenant-id'] -eq 'discovered-tenant'
+        }
+    }
+
+    It 'bootstraps XSRF exactly once when the caller does not provide it' {
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            param($WebSession)
+            $cookie = [System.Net.Cookie]::new('xsrf-token', $script:FakeXSRF, '/', 'security.microsoft.com')
+            $WebSession.Cookies.Add([Uri]'https://security.microsoft.com/', $cookie)
+            [PSCustomObject]@{ StatusCode = 200 }
+        }
+
+        Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -ResourceName MicrosoftGraph
+
+        Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1 -Exactly -Scope It -ParameterFilter {
+            $UseBasicParsing -and
+            "$ErrorAction" -eq 'SilentlyContinue' -and
+            "$Method" -eq 'Get' -and
+            $Uri -eq 'https://security.microsoft.com/' -and
+            $WebSession -is [Microsoft.PowerShell.Commands.WebRequestSession]
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+            $Headers['X-XSRF-TOKEN'] -eq 'fake+xsrf/token'
+        }
+    }
+
+    It 'throws when XSRF bootstrapping does not return the cookie' {
+        Mock -ModuleName TokenTactics Invoke-WebRequest { [PSCustomObject]@{ StatusCode = 200 } }
+
+        { Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -ResourceName MicrosoftGraph } |
+            Should -Throw '*Failed to obtain XSRF-TOKEN*'
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 0 -Exactly -Scope It
+    }
+
+    It 'propagates token endpoint failures' {
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw 'XDR token request failed' }
+
+        { Get-EntraIDTokenFromSCCAUTHCookie -SCCAuth $script:FakeSCCAuth -XSRF $script:FakeXSRF -ResourceName MicrosoftGraph } |
+            Should -Throw '*XDR token request failed*'
     }
 }

--- a/tests/Get-ForgedUserAgent.Tests.ps1
+++ b/tests/Get-ForgedUserAgent.Tests.ps1
@@ -127,8 +127,9 @@ Describe "Get-ForgedUserAgent" {
 
     Context "Invalid browser for device" {
         It "Falls back to a default and emits a warning for Windows with invalid browser" {
-            $result = Get-ForgedUserAgent -Device Windows -Browser Safari
+            $result = Get-ForgedUserAgent -Device Windows -Browser Safari -WarningVariable warning
             $result | Should -Not -BeNullOrEmpty
+            $warning.Message | Should -Match 'not valid'
         }
     }
 }

--- a/tests/Get-ForgedUserAgent.Tests.ps1
+++ b/tests/Get-ForgedUserAgent.Tests.ps1
@@ -1,0 +1,134 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "Get-ForgedUserAgent" {
+    Context "Default (Windows/Edge)" {
+        It "Returns a non-empty string" {
+            $result = Get-ForgedUserAgent
+            $result | Should -Not -BeNullOrEmpty
+        }
+
+        It "Returns Windows Edge UA by default" {
+            $result = Get-ForgedUserAgent
+            $result | Should -Match "Windows NT"
+            $result | Should -Match "Edg"
+        }
+    }
+
+    Context "Windows device" {
+        It "Returns IE user agent for Windows/IE" {
+            $result = Get-ForgedUserAgent -Device Windows -Browser IE
+            $result | Should -Match "Trident"
+        }
+
+        It "Returns Chrome user agent for Windows/Chrome" {
+            $result = Get-ForgedUserAgent -Device Windows -Browser Chrome
+            $result | Should -Match "Chrome"
+            $result | Should -Match "Windows NT"
+        }
+
+        It "Returns Firefox user agent for Windows/Firefox" {
+            $result = Get-ForgedUserAgent -Device Windows -Browser Firefox
+            $result | Should -Match "Firefox"
+            $result | Should -Match "Windows NT"
+        }
+    }
+
+    Context "Mac device" {
+        It "Returns Safari user agent for Mac/Safari" {
+            $result = Get-ForgedUserAgent -Device Mac -Browser Safari
+            $result | Should -Match "Macintosh"
+            $result | Should -Match "Safari"
+        }
+
+        It "Returns Chrome user agent for Mac/Chrome" {
+            $result = Get-ForgedUserAgent -Device Mac -Browser Chrome
+            $result | Should -Match "Macintosh"
+            $result | Should -Match "Chrome"
+        }
+
+        It "Returns Edge user agent for Mac/Edge" {
+            $result = Get-ForgedUserAgent -Device Mac -Browser Edge
+            $result | Should -Match "Macintosh"
+            $result | Should -Match "Edg"
+        }
+
+        It "Returns Firefox user agent for Mac/Firefox" {
+            $result = Get-ForgedUserAgent -Device Mac -Browser Firefox
+            $result | Should -Match "Macintosh"
+            $result | Should -Match "Firefox"
+        }
+    }
+
+    Context "iPhone device" {
+        It "Returns Safari user agent for iPhone/Safari" {
+            $result = Get-ForgedUserAgent -Device iPhone -Browser Safari
+            $result | Should -Match "iPhone"
+            $result | Should -Match "Safari"
+        }
+
+        It "Returns Chrome user agent for iPhone/Chrome" {
+            $result = Get-ForgedUserAgent -Device iPhone -Browser Chrome
+            $result | Should -Match "iPhone"
+            $result | Should -Match "CriOS"
+        }
+
+        It "Returns Edge user agent for iPhone/Edge" {
+            $result = Get-ForgedUserAgent -Device iPhone -Browser Edge
+            $result | Should -Match "iPhone"
+            $result | Should -Match "EdgiOS"
+        }
+    }
+
+    Context "AndroidMobile device" {
+        It "Returns Android user agent for AndroidMobile/Android" {
+            $result = Get-ForgedUserAgent -Device AndroidMobile -Browser Android
+            $result | Should -Match "Android"
+        }
+
+        It "Returns Chrome user agent for AndroidMobile/Chrome" {
+            $result = Get-ForgedUserAgent -Device AndroidMobile -Browser Chrome
+            $result | Should -Match "Android"
+            $result | Should -Match "Chrome"
+        }
+    }
+
+    Context "Linux device" {
+        It "Returns Firefox user agent for Linux/Firefox" {
+            $result = Get-ForgedUserAgent -Device Linux -Browser Firefox
+            $result | Should -Match "Linux"
+            $result | Should -Match "Firefox"
+        }
+
+        It "Returns Chrome user agent for Linux/Chrome" {
+            $result = Get-ForgedUserAgent -Device Linux -Browser Chrome
+            $result | Should -Match "Linux"
+            $result | Should -Match "Chrome"
+        }
+    }
+
+    Context "OS/2 device" {
+        It "Returns Firefox user agent for OS/2" {
+            $result = Get-ForgedUserAgent -Device "OS/2" -Browser Firefox
+            $result | Should -Match "OS/2"
+            $result | Should -Match "Firefox"
+        }
+    }
+
+    Context "CustomUserAgent" {
+        It "Returns the custom user agent string when provided" {
+            $custom = "MyCustomAgent/1.0"
+            $result = Get-ForgedUserAgent -CustomUserAgent $custom
+            $result | Should -Be $custom
+        }
+    }
+
+    Context "Invalid browser for device" {
+        It "Falls back to a default and emits a warning for Windows with invalid browser" {
+            $result = Get-ForgedUserAgent -Device Windows -Browser Safari
+            $result | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/tests/Get-TenantId.Tests.ps1
+++ b/tests/Get-TenantId.Tests.ps1
@@ -1,0 +1,33 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "Get-TenantID" {
+    BeforeAll {
+        # Build a fake openid-configuration response where the tenant GUID is embedded
+        # in the authorization_endpoint path segment.
+        $script:FakeTenantId = "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb"
+        $script:FakeOpenIdConfig = [PSCustomObject]@{
+            authorization_endpoint = "https://login.microsoftonline.com/$($script:FakeTenantId)/oauth2/authorize"
+        }
+    }
+
+    It "Returns the tenant GUID extracted from authorization_endpoint" {
+        Mock -ModuleName TokenTactics Invoke-RestMethod {
+            return $script:FakeOpenIdConfig
+        }
+        $result = Get-TenantID -domain "contoso.com"
+        $result | Should -Be $script:FakeTenantId
+    }
+
+    It "Calls the correct openid-configuration URL for the supplied domain" {
+        Mock -ModuleName TokenTactics Invoke-RestMethod {
+            return $script:FakeOpenIdConfig
+        } -Verifiable
+        Get-TenantID -domain "fabrikam.com"
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Uri -match "fabrikam\.com"
+        } -Times 1
+    }
+}

--- a/tests/Get-TenantId.Tests.ps1
+++ b/tests/Get-TenantId.Tests.ps1
@@ -27,7 +27,22 @@ Describe "Get-TenantID" {
         } -Verifiable
         Get-TenantID -domain "fabrikam.com"
         Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
-            $Uri -match "fabrikam\.com"
-        } -Times 1
+            "$Method" -eq 'Get' -and
+            $Uri -eq 'https://login.microsoftonline.com/fabrikam.com/.well-known/openid-configuration'
+        } -Times 1 -Exactly -Scope It
+    }
+
+    It 'throws when the authorization endpoint is missing or malformed' {
+        Mock -ModuleName TokenTactics Invoke-RestMethod {
+            [PSCustomObject]@{ authorization_endpoint = 'https://login.microsoftonline.com/not-a-guid/oauth2/authorize' }
+        }
+
+        { Get-TenantID -Domain 'contoso.com' } | Should -Throw '*valid tenant ID*'
+    }
+
+    It 'propagates discovery request failures' {
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw 'discovery unavailable' }
+
+        { Get-TenantID -Domain 'contoso.com' } | Should -Throw '*discovery unavailable*'
     }
 }

--- a/tests/Invoke-EntraErrorHandling.Tests.ps1
+++ b/tests/Invoke-EntraErrorHandling.Tests.ps1
@@ -1,0 +1,101 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+}
+
+Describe "Invoke-EntraErrorHandling" {
+    Context "Error code 50058 (session information not sufficient)" {
+        It "Outputs a message referencing error code 50058" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{ sErrorCode = "50058" })
+            }
+            ($output -join "`n") | Should -Match "50058"
+        }
+
+        It "Outputs a message about session information" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{ sErrorCode = "50058" })
+            }
+            ($output -join "`n") | Should -Match "session"
+        }
+    }
+
+    Context "Error code 53003 (Conditional Access block)" {
+        It "Outputs a message referencing error code 53003" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{ sErrorCode = "53003" })
+            }
+            ($output -join "`n") | Should -Match "53003"
+        }
+
+        It "Mentions Conditional Access" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{
+                    sErrorCode             = "53003"
+                    urlTokenBindingLearnMore = $null
+                })
+            }
+            ($output -join "`n") | Should -Match "Conditional Access"
+        }
+    }
+
+    Context "Generic error code with title and description" {
+        It "Outputs a message containing the error code" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{
+                    sErrorCode        = "70011"
+                    iErrorTitle       = 1
+                    iErrorDescription = 1
+                })
+            }
+            ($output -join "`n") | Should -Match "70011"
+        }
+    }
+
+    Context "No error code - strMainMessage present" {
+        It "Outputs the strMainMessage value" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{
+                    sErrorCode              = ""
+                    strMainMessage          = "Custom error occurred"
+                    strServiceExceptionMessage = "Details here"
+                })
+            }
+            ($output -join "`n") | Should -Match "Custom error occurred"
+        }
+    }
+
+    Context "No error code and no main message" {
+        It "Outputs a fallback 'No error code received' message" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{
+                    sErrorCode     = ""
+                    strMainMessage = ""
+                })
+            }
+            ($output -join "`n") | Should -Match "No error code"
+        }
+    }
+
+    Context "Optional diagnostic fields" {
+        It "Outputs Device Id when sDeviceId is present" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{
+                    sErrorCode  = "50058"
+                    sDeviceId   = "device-abc-123"
+                })
+            }
+            ($output -join "`n") | Should -Match "device-abc-123"
+        }
+
+        It "Outputs Correlation Id when correlationId is present" {
+            $output = InModuleScope TokenTactics {
+                Invoke-EntraErrorHandling -AppConfig ([PSCustomObject]@{
+                    sErrorCode    = "50058"
+                    correlationId = "corr-123"
+                })
+            }
+            ($output -join "`n") | Should -Match "corr-123"
+        }
+    }
+}

--- a/tests/Invoke-Tests.ps1
+++ b/tests/Invoke-Tests.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding()]
+param()
+
+$requiredVersion = [version]'5.7.1'
+$pester = Get-Module -ListAvailable Pester |
+    Where-Object Version -EQ $requiredVersion |
+    Select-Object -First 1
+
+if (-not $pester) {
+    throw "Pester $requiredVersion is required. Install it with: Install-Module Pester -RequiredVersion $requiredVersion -Scope CurrentUser"
+}
+
+Import-Module $pester.Path -Force
+$settings = Import-PowerShellDataFile (Join-Path $PSScriptRoot 'PesterConfiguration.psd1')
+$configuration = New-PesterConfiguration -Hashtable $settings
+$result = Invoke-Pester -Configuration $configuration
+
+if ($result.Result -ne 'Passed') {
+    throw "Pester run failed: $($result.FailedCount) test(s) failed."
+}

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -1,0 +1,89 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+
+    $script:ExpectedFunctions = @(
+        'Clear-Token'
+        'ConvertFrom-JWTtoken'
+        'ConvertTo-PEMPrivateKey'
+        'Get-EntraIDAuthorizationCode'
+        'Get-EntraIDToken'
+        'Get-EntraIDTokenFromAuthorizationCode'
+        'Get-EntraIDTokenFromCookie'
+        'Get-EntraIDTokenFromESTSCookie'
+        'Get-EntraIDTokenFromRefreshTokenCredentialCookie'
+        'Get-EntraIDTokenFromSCCAUTHCookie'
+        'Get-ForgedUserAgent'
+        'Get-TenantID'
+        'Invoke-EntraIDPasskeyLogin'
+        'Invoke-RefreshToAzureCoreManagementToken'
+        'Invoke-RefreshToAzureKeyVaultToken'
+        'Invoke-RefreshToAzureManagementToken'
+        'Invoke-RefreshToAzureStorageToken'
+        'Invoke-RefreshToDeviceRegistrationToken'
+        'Invoke-RefreshToDODMSGraphToken'
+        'Invoke-RefreshToGraphToken'
+        'Invoke-RefreshToMAMToken'
+        'Invoke-RefreshToMSGraphToken'
+        'Invoke-RefreshToMSManageToken'
+        'Invoke-RefreshToMSTeamsToken'
+        'Invoke-RefreshToOfficeAppsToken'
+        'Invoke-RefreshToOfficeManagementToken'
+        'Invoke-RefreshToOneDriveToken'
+        'Invoke-RefreshToOutlookToken'
+        'Invoke-RefreshToSharePointToken'
+        'Invoke-RefreshToSubstrateToken'
+        'Invoke-RefreshToYammerToken'
+    )
+
+    $script:ExpectedAliases = @{
+        'Forge-UserAgent'                                = 'Get-ForgedUserAgent'
+        'Get-AzureAuthorizationCode'                    = 'Get-EntraIDAuthorizationCode'
+        'Get-AzureToken'                                = 'Get-EntraIDToken'
+        'Get-AzureTokenFromAuthorizationCode'           = 'Get-EntraIDTokenFromAuthorizationCode'
+        'Get-AzureTokenFromCookie'                      = 'Get-EntraIDTokenFromCookie'
+        'Get-AzureTokenFromESTSCookie'                  = 'Get-EntraIDTokenFromESTSCookie'
+        'Get-AzureTokenFromRefreshTokenCredentialCookie' = 'Get-EntraIDTokenFromRefreshTokenCredentialCookie'
+        'Parse-JWTtoken'                                = 'ConvertFrom-JWTtoken'
+        'RefreshTo-AzureCoreManagementToken'            = 'Invoke-RefreshToAzureCoreManagementToken'
+        'RefreshTo-AzureKeyVaultToken'                  = 'Invoke-RefreshToAzureKeyVaultToken'
+        'RefreshTo-AzureManagementToken'                = 'Invoke-RefreshToAzureManagementToken'
+        'RefreshTo-AzureStorageToken'                   = 'Invoke-RefreshToAzureStorageToken'
+        'RefreshTo-DeviceRegistrationToken'             = 'Invoke-RefreshToDeviceRegistrationToken'
+        'RefreshTo-DODMSGraphToken'                     = 'Invoke-RefreshToDODMSGraphToken'
+        'RefreshTo-GraphToken'                          = 'Invoke-RefreshToGraphToken'
+        'RefreshTo-MAMToken'                            = 'Invoke-RefreshToMAMToken'
+        'RefreshTo-MSGraphToken'                        = 'Invoke-RefreshToMSGraphToken'
+        'RefreshTo-MSManageToken'                       = 'Invoke-RefreshToMSManageToken'
+        'RefreshTo-MSTeamsToken'                        = 'Invoke-RefreshToMSTeamsToken'
+        'RefreshTo-OfficeAppsToken'                     = 'Invoke-RefreshToOfficeAppsToken'
+        'RefreshTo-OfficeManagementToken'               = 'Invoke-RefreshToOfficeManagementToken'
+        'RefreshTo-OneDriveToken'                       = 'Invoke-RefreshToOneDriveToken'
+        'RefreshTo-OutlookToken'                        = 'Invoke-RefreshToOutlookToken'
+        'RefreshTo-SharePointToken'                     = 'Invoke-RefreshToSharePointToken'
+        'RefreshTo-SubstrateToken'                      = 'Invoke-RefreshToSubstrateToken'
+        'RefreshTo-YammerToken'                         = 'Invoke-RefreshToYammerToken'
+    }
+}
+
+Describe 'TokenTactics module contract' {
+    It 'exports exactly the supported functions' {
+        $actual = @(Get-Command -Module TokenTactics -CommandType Function | Select-Object -ExpandProperty Name | Sort-Object)
+        $actual | Should -Be ($script:ExpectedFunctions | Sort-Object)
+    }
+
+    It 'exports exactly the supported aliases with the correct targets' {
+        $actual = @(Get-Command -Module TokenTactics -CommandType Alias)
+        @($actual.Name | Sort-Object) | Should -Be @($script:ExpectedAliases.Keys | Sort-Object)
+
+        foreach ($alias in $actual) {
+            $alias.Definition | Should -Be $script:ExpectedAliases[$alias.Name]
+        }
+    }
+
+    It 'keeps implementation helpers private' {
+        Get-Command ConvertTo-URLParameters -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+        Get-Command Invoke-RefreshToToken -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+        Get-Command New-FidoSignature -ErrorAction SilentlyContinue | Should -BeNullOrEmpty
+    }
+}

--- a/tests/PesterConfiguration.psd1
+++ b/tests/PesterConfiguration.psd1
@@ -1,0 +1,24 @@
+@{
+    Run          = @{
+        Path     = './tests'
+        PassThru = $true
+    }
+    Filter       = @{
+        ExcludeTag = @('Integration')
+    }
+    Output       = @{
+        Verbosity = 'Normal'
+    }
+    TestResult   = @{
+        Enabled      = $true
+        OutputFormat = 'NUnitXml'
+        OutputPath   = './test-results.xml'
+    }
+    CodeCoverage = @{
+        Enabled               = $true
+        Path                  = @('./modules/*.ps1', './TokenTactics.psm1')
+        CoveragePercentTarget = 60
+        OutputFormat          = 'JaCoCo'
+        OutputPath            = './coverage.xml'
+    }
+}

--- a/tests/TokenHandler.Tests.ps1
+++ b/tests/TokenHandler.Tests.ps1
@@ -1,0 +1,579 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+
+    # Build a fake token response object used across all tests
+    $script:FakeTenantId = "aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb"
+    $script:FakeTokenResponse = [PSCustomObject]@{
+        access_token  = $script:FakeAccessToken
+        refresh_token = $script:FakeRefreshToken
+        token_type    = "Bearer"
+        expires_in    = 3600
+        ext_expires_in = 3600
+        scope         = "User.Read"
+    }
+    $script:FakeOpenIdConfig = [PSCustomObject]@{
+        authorization_endpoint = "https://login.microsoftonline.com/$($script:FakeTenantId)/oauth2/authorize"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToToken (internal)
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+
+    It "Calls Get-TenantID with the supplied domain" {
+        InModuleScope TokenTactics {
+            Invoke-RefreshToToken -Domain "contoso.com" -refreshToken "rt1" -ClientID "client1" -Scope "https://graph.microsoft.com/.default"
+        }
+        Should -Invoke -ModuleName TokenTactics Get-TenantID -ParameterFilter { $domain -eq "contoso.com" } -Times 1
+    }
+
+    It "Calls the v2.0 token endpoint by default" {
+        InModuleScope TokenTactics {
+            Invoke-RefreshToToken -Domain "contoso.com" -refreshToken "rt1" -ClientID "client1" -Scope "https://graph.microsoft.com/.default"
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Uri -match "oauth2/v2\.0/token"
+        } -Times 1
+    }
+
+    It "Uses the v1 token endpoint when -UseV1Endpoint is set" {
+        InModuleScope TokenTactics {
+            Invoke-RefreshToToken -Domain "contoso.com" -refreshToken "rt1" -ClientID "client1" -Scope "openid" -UseV1Endpoint
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Uri -match "oauth2/token" -and $Uri -notmatch "v2\.0"
+        } -Times 1
+    }
+
+    It "Returns the token response from Invoke-RestMethod" {
+        $result = InModuleScope TokenTactics {
+            Invoke-RefreshToToken -Domain "contoso.com" -refreshToken "rt1" -ClientID "client1" -Scope "https://graph.microsoft.com/.default"
+        }
+        $result.token_type | Should -Be "Bearer"
+    }
+
+    It "Adds CAE claims to the body when -UseCAE is set" {
+        InModuleScope TokenTactics {
+            Invoke-RefreshToToken -Domain "contoso.com" -refreshToken "rt1" -ClientID "client1" -Scope "https://graph.microsoft.com/.default" -UseCAE
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body.ContainsKey("claims") -and $Body["claims"] -match "cp1"
+        } -Times 1
+    }
+
+    It "Uses the DoD login endpoint when -UseDoD is set" {
+        InModuleScope TokenTactics {
+            Invoke-RefreshToToken -Domain "contoso.com" -refreshToken "rt1" -ClientID "client1" -Scope "https://dod-graph.microsoft.us/.default" -UseDoD
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Uri -match "microsoftonline\.us"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToMSGraphToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToMSGraphToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name MSGraphToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:MSGraphToken after a successful call" {
+        Invoke-RefreshToMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:MSGraphToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the MSGraph scope" {
+        Invoke-RefreshToMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "graph\.microsoft\.com"
+        } -Times 1
+    }
+
+    It "Outputs a success message" {
+        $output = Invoke-RefreshToMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        ($output | ForEach-Object { "$_" } | Where-Object { $_ -match "MSGraphToken" }).Count | Should -BeGreaterThan 0
+    }
+
+    It "Outputs an error message when Invoke-RestMethod throws" {
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw "network error" } -Verifiable
+        $output = Invoke-RefreshToMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        ($output | ForEach-Object { "$_" } | Where-Object { $_ -match "Could not get tokens" }).Count | Should -BeGreaterThan 0
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToGraphToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToGraphToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name GraphToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:GraphToken after a successful call" {
+        Invoke-RefreshToGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:GraphToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the Windows Graph (graph.windows.net) scope" {
+        Invoke-RefreshToGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "graph\.windows\.net"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToMSTeamsToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToMSTeamsToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name MSTeamsToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:MSTeamsToken after a successful call" {
+        Invoke-RefreshToMSTeamsToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:MSTeamsToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the Teams (api.spaces.skype.com) scope" {
+        Invoke-RefreshToMSTeamsToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "api\.spaces\.skype\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToOutlookToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToOutlookToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name OutlookToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:OutlookToken after a successful call" {
+        Invoke-RefreshToOutlookToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:OutlookToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the Outlook (outlook.office365.com) scope" {
+        Invoke-RefreshToOutlookToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "outlook\.office365\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToSubstrateToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToSubstrateToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name SubstrateToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:SubstrateToken after a successful call" {
+        Invoke-RefreshToSubstrateToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:SubstrateToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the Substrate (substrate.office.com) scope" {
+        Invoke-RefreshToSubstrateToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "substrate\.office\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToOfficeManagementToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToOfficeManagementToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name OfficeManagementToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:OfficeManagementToken after a successful call" {
+        Invoke-RefreshToOfficeManagementToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:OfficeManagementToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the Office Management (manage.office.com) scope" {
+        Invoke-RefreshToOfficeManagementToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "manage\.office\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToOfficeAppsToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToOfficeAppsToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name OfficeAppsToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:OfficeAppsToken after a successful call" {
+        Invoke-RefreshToOfficeAppsToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:OfficeAppsToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the OfficeApps (officeapps.live.com) scope" {
+        Invoke-RefreshToOfficeAppsToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "officeapps\.live\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToAzureCoreManagementToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToAzureCoreManagementToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name AzureCoreManagementToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:AzureCoreManagementToken after a successful call" {
+        Invoke-RefreshToAzureCoreManagementToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:AzureCoreManagementToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the AzureCore (management.core.windows.net) scope" {
+        Invoke-RefreshToAzureCoreManagementToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "management\.core\.windows\.net"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToAzureManagementToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToAzureManagementToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name AzureManagementToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:AzureManagementToken after a successful call" {
+        Invoke-RefreshToAzureManagementToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:AzureManagementToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the AzureManagement (management.azure.com) scope" {
+        Invoke-RefreshToAzureManagementToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "management\.azure\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToAzureStorageToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToAzureStorageToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name AzureStorageToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:AzureStorageToken after a successful call" {
+        Invoke-RefreshToAzureStorageToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:AzureStorageToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the AzureStorage (storage.azure.com) scope" {
+        Invoke-RefreshToAzureStorageToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "storage\.azure\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToAzureKeyVaultToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToAzureKeyVaultToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name AzureKeyVaultToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:AzureKeyVaultToken after a successful call" {
+        Invoke-RefreshToAzureKeyVaultToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:AzureKeyVaultToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the AzureKeyVault (vault.azure.net) scope" {
+        Invoke-RefreshToAzureKeyVaultToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "vault\.azure\.net"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToMAMToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToMAMToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name MAMToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:MAMToken after a successful call" {
+        Invoke-RefreshToMAMToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:MAMToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the MAM (intunemam.microsoftonline.com) scope" {
+        Invoke-RefreshToMAMToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "intunemam\.microsoftonline\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToMSManageToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToMSManageToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name MSManageToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:MSManageToken after a successful call" {
+        Invoke-RefreshToMSManageToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:MSManageToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the MSManage (enrollment.manage.microsoft.com) scope" {
+        Invoke-RefreshToMSManageToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "enrollment\.manage\.microsoft\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToDODMSGraphToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToDODMSGraphToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name DODMSGraphToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:DODMSGraphToken after a successful call" {
+        Invoke-RefreshToDODMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:DODMSGraphToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the DoD Graph (dod-graph.microsoft.us) scope" {
+        Invoke-RefreshToDODMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "dod-graph\.microsoft\.us"
+        } -Times 1
+    }
+
+    It "Calls the DoD login endpoint" {
+        Invoke-RefreshToDODMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Uri -match "microsoftonline\.us"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToSharePointToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToSharePointToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name SharePointToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:SharePointToken after a successful call" {
+        Invoke-RefreshToSharePointToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken -SharePointTenantName "contoso"
+        $global:SharePointToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Builds the scope using the provided SharePointTenantName" {
+        Invoke-RefreshToSharePointToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken -SharePointTenantName "contoso"
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "contoso\.sharepoint\.com"
+        } -Times 1
+    }
+
+    It "Appends -admin suffix when -SharePointUseAdmin is set" {
+        Invoke-RefreshToSharePointToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken -SharePointTenantName "contoso" -SharePointUseAdmin
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "contoso-admin\.sharepoint\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToOneDriveToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToOneDriveToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name OneDriveToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:OneDriveToken after a successful call" {
+        Invoke-RefreshToOneDriveToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:OneDriveToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the OneDrive (officeapps.live.com) scope" {
+        Invoke-RefreshToOneDriveToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["scope"] -match "officeapps\.live\.com"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToDeviceRegistrationToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToDeviceRegistrationToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name DeviceRegistrationToken -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:DeviceRegistrationToken after a successful call" {
+        Invoke-RefreshToDeviceRegistrationToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $global:DeviceRegistrationToken | Should -Not -BeNullOrEmpty
+    }
+
+    It "Uses the v1 endpoint for device registration" {
+        Invoke-RefreshToDeviceRegistrationToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Uri -match "oauth2/token" -and $Uri -notmatch "v2\.0"
+        } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Get-EntraIDTokenFromAuthorizationCode
+# ---------------------------------------------------------------------------
+Describe "Get-EntraIDTokenFromAuthorizationCode" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name response -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name TokenDomain -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name TokenUpn -ErrorAction SilentlyContinue
+    }
+
+    It "Sets `$global:response after a successful call" {
+        Get-EntraIDTokenFromAuthorizationCode -AuthorizationCode "auth-code-123"
+        $global:response | Should -Not -BeNullOrEmpty
+    }
+
+    It "Calls the v2.0 token endpoint by default" {
+        Get-EntraIDTokenFromAuthorizationCode -AuthorizationCode "auth-code-123"
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Uri -match "oauth2/v2\.0/token"
+        } -Times 1
+    }
+
+    It "Sends grant_type=authorization_code" {
+        Get-EntraIDTokenFromAuthorizationCode -AuthorizationCode "auth-code-123"
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["grant_type"] -eq "authorization_code"
+        } -Times 1
+    }
+
+    It "Extracts authorization code from a RequestURL" {
+        $requestUrl = "ms-appx-web://Microsoft.AAD.BrokerPlugin/S-1-15-2-123?code=extracted-code-456&state=abc"
+        Get-EntraIDTokenFromAuthorizationCode -RequestURL $requestUrl
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
+            $Body -is [hashtable] -and $Body["code"] -eq "extracted-code-456"
+        } -Times 1
+    }
+
+    It "Sets `$global:TokenDomain from the token's upn" {
+        Get-EntraIDTokenFromAuthorizationCode -AuthorizationCode "auth-code-123"
+        $global:TokenDomain | Should -Be "contoso.com"
+    }
+
+    It "Sets `$global:TokenUpn from the token" {
+        Get-EntraIDTokenFromAuthorizationCode -AuthorizationCode "auth-code-123"
+        $global:TokenUpn | Should -Be "test.user@contoso.com"
+    }
+}

--- a/tests/TokenHandler.Tests.ps1
+++ b/tests/TokenHandler.Tests.ps1
@@ -75,6 +75,33 @@ Describe "Invoke-RefreshToToken" {
             $Uri -match "microsoftonline\.us"
         } -Times 1
     }
+
+    It "sends one exact refresh-token request" {
+        InModuleScope TokenTactics {
+            Invoke-RefreshToToken `
+                -Domain 'contoso.com' `
+                -refreshToken 'exact-refresh-token' `
+                -ClientID 'exact-client-id' `
+                -Scope 'api://exact/.default offline_access' `
+                -CustomUserAgent 'Exact-Agent/1.0'
+        }
+
+        Should -Invoke -ModuleName TokenTactics Get-TenantID -Times 1 -Exactly -Scope It -ParameterFilter {
+            $domain -eq 'contoso.com'
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            $Uri -eq "https://login.microsoftonline.com/$script:FakeTenantId/oauth2/v2.0/token" -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'Exact-Agent/1.0' -and
+            $Body.Count -eq 4 -and
+            $Body['scope'] -eq 'api://exact/.default offline_access' -and
+            $Body['client_id'] -eq 'exact-client-id' -and
+            $Body['grant_type'] -eq 'refresh_token' -and
+            $Body['refresh_token'] -eq 'exact-refresh-token'
+        }
+    }
 }
 
 # ---------------------------------------------------------------------------
@@ -108,8 +135,10 @@ Describe "Invoke-RefreshToMSGraphToken" {
 
     It "Outputs an error message when Invoke-RestMethod throws" {
         Mock -ModuleName TokenTactics Invoke-RestMethod { throw "network error" } -Verifiable
-        $output = Invoke-RefreshToMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken
+        $output = @(Invoke-RefreshToMSGraphToken -Domain "contoso.com" -RefreshToken $script:FakeRefreshToken 2>&1)
         ($output | ForEach-Object { "$_" } | Where-Object { $_ -match "Could not get tokens" }).Count | Should -BeGreaterThan 0
+        ($output -join "`n") | Should -Match 'network error'
+        @($output | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] }) | Should -BeNullOrEmpty
     }
 }
 
@@ -499,6 +528,31 @@ Describe "Invoke-RefreshToOneDriveToken" {
         Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -ParameterFilter {
             $Body -is [hashtable] -and $Body["scope"] -match "officeapps\.live\.com"
         } -Times 1
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Invoke-RefreshToYammerToken
+# ---------------------------------------------------------------------------
+Describe "Invoke-RefreshToYammerToken" {
+    BeforeAll {
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+        Mock -ModuleName TokenTactics Invoke-RestMethod { return $script:FakeTokenResponse }
+    }
+    AfterEach {
+        Remove-Variable -Scope Global -Name YammerToken -ErrorAction SilentlyContinue
+    }
+
+    It "sets the Yammer token using the Yammer resource rather than the Teams resource" {
+        Invoke-RefreshToYammerToken -Domain 'contoso.com' -RefreshToken $script:FakeRefreshToken
+
+        $global:YammerToken | Should -Be $script:FakeTokenResponse
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It -ParameterFilter {
+            $Body['scope'] -eq 'https://www.yammer.com/.default offline_access openid' -and
+            $Body['scope'] -notmatch 'api\.spaces\.skype\.com' -and
+            $Body['grant_type'] -eq 'refresh_token' -and
+            $Body['refresh_token'] -eq $script:FakeRefreshToken
+        }
     }
 }
 

--- a/tests/fixtures/TestData.ps1
+++ b/tests/fixtures/TestData.ps1
@@ -1,0 +1,26 @@
+# Shared test fixtures for TokenTacticsV2 Pester tests
+
+# A JWT token with fixed timestamps and known payload values.
+# Header: { typ: "JWT", kid: "test-key-id", alg: "RS256" }
+# Payload:
+#   iss  = "https://sts.windows.net/00000000-0000-0000-0000-000000000001/"
+#   aud  = "https://graph.microsoft.com"
+#   oid  = "00000000-0000-0000-0000-000000000002"
+#   name = "Test User"
+#   tid  = "00000000-0000-0000-0000-000000000001"
+#   nbf  = 1700000000  (2023-11-14T22:13:20Z)
+#   exp  = 1700003600  (2023-11-14T23:13:20Z)
+#   upn  = "test.user@contoso.com"
+#   scp  = "User.Read"
+#   iat  = 1700000000
+# Signature is intentionally fake (JWT validation is not performed).
+$script:TestJWT = "eyJ0eXAiOiJKV1QiLCJraWQiOiJ0ZXN0LWtleS1pZCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8wMDAwMDAwMC0wMDAwLTAwMDAtMDAwMC0wMDAwMDAwMDAwMDEvIiwiYXVkIjoiaHR0cHM6Ly9ncmFwaC5taWNyb3NvZnQuY29tIiwib2lkIjoiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAyIiwibmFtZSI6IlRlc3QgVXNlciIsInRpZCI6IjAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMSIsIm5iZiI6MTcwMDAwMDAwMCwiZXhwIjoxNzAwMDAzNjAwLCJ1cG4iOiJ0ZXN0LnVzZXJAY29udG9zby5jb20iLCJzY3AiOiJVc2VyLlJlYWQiLCJpYXQiOjE3MDAwMDAwMDB9.fakesignaturefortesting"
+
+# A fake refresh token used when testing token-refresh functions
+$script:FakeRefreshToken = "0.FakeRefreshToken.ForTesting"
+
+# A fake access token (same as TestJWT for simplicity)
+$script:FakeAccessToken = $script:TestJWT
+
+# Module manifest path
+$script:ModulePath = Join-Path $PSScriptRoot ".." ".." "TokenTactics.psd1"


### PR DESCRIPTION
Closes #12

## Summary

Adds 134 Pester 5 tests covering all exported user-facing functions without requiring a real Entra ID connection — all network calls (`Invoke-RestMethod`, `Invoke-WebRequest`) are mocked.

## Test Files

| File | Tests | Description |
|------|-------|-------------|
| `tests/fixtures/TestData.ps1` | — | Shared fixtures: fixed JWT, fake tokens, module path |
| `tests/ConvertFrom-JWTtoken.Tests.ps1` | 12 | JWT decoding, computed properties (IssuedAt, ValidForHours, etc.) |
| `tests/ConvertTo-Base64Url.Tests.ps1` | 4 | Base64URL encoding (URL-safe chars, no padding) |
| `tests/ConvertTo-URLParameters.Tests.ps1` | 4 | URL query string → hashtable parsing |
| `tests/ConvertTo-PEMPrivateKey.Tests.ps1` | 5 | PEM wrapping, 64-char line breaks, URL-safe char replacement |
| `tests/Get-ForgedUserAgent.Tests.ps1` | 20 | All Device+Browser combos, custom UA, invalid combo fallback |
| `tests/CodeVerifier.Tests.ps1` | 7 | PKCE `Get-TTCodeVerifier` and `Get-TTCodeChallenge` |
| `tests/Clear-Token.Tests.ps1` | 6 | Global token variable cleanup (`-Token All` and specific tokens) |
| `tests/Invoke-EntraErrorHandling.Tests.ps1` | 9 | Error codes 50058, 53003, generic, strMainMessage, diagnostic fields |
| `tests/Get-TenantId.Tests.ps1` | 4 | Tenant GUID extraction from OpenID config (mocked) |
| `tests/TokenHandler.Tests.ps1` | 57 | All `Invoke-RefreshTo*` wrappers + `Get-EntraIDTokenFromAuthorizationCode` |
| `tests/Get-EntraIDTokenFromSCCAUTHCookie.Tests.ps1` | 6 | Cookie-based token, XSRF handling, ResourceName mapping |

## Running Tests

```powershell
Invoke-Pester -Path ./tests -Output Detailed
```

Result: **134 tests passed, 0 failed**