### PR TITLE
feat: add nested app auth token cmdlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,25 @@ Now the same capabilities are available in TokenTacticsV2.
 
 ![How to use the new cmdlets](./images/EntraIDAuthorizationCodeFlow.gif)
 
+### Get a nested app token using NAA / BroCi
+
+`Get-EntraIDTokenFromNestedAppAuth` exchanges a broker application's refresh token for a token issued to a nested application. By default, the cmdlet uses the Azure Portal broker (`c44b4083-3bb0-49c1-b47d-974e53cbdf3c`) and the ADIbizaUX nested client (`74658136-14ec-4630-ad9b-26e160ff0fc6`) with Microsoft Graph scopes. Override the broker, nested client, scope, and redirect values as needed.
+
+Supported broker presets: `AzurePortal`, `Teams`, `Microsoft365`, `EntraAdminCenter`, `IntuneAdminCenter`, `Defender`, `Purview`.
+
+```powershell
+Get-EntraIDTokenFromNestedAppAuth `
+    -BrokerPreset Defender `
+    -TenantId "e3686c4f-af27-4f22-b9de-062f05b93aac" `
+    -RefreshToken $response.refresh_token `
+    -AnchorMailbox "Oid:3135fd4e-140c-43c0-ad02-718913648fb9@e3686c4f-af27-4f22-b9de-062f05b93aac" `
+    -UseCAE
+```
+
+If you omit `-RefreshToken`, the cmdlet falls back to `$response.refresh_token`. If you omit `-RedirectUri`, it is derived from `-BrokerClientId` and `-BrokerRedirectUri` using the brokered `brk-<brokerClientId>://<broker-host>` format. Explicit `-BrokerClientId`, `-BrokerRedirectUri`, and `-AuthorityHost` values override `-BrokerPreset`.
+
+The `Teams` preset follows the newer `teams.cloud.microsoft` broker shape and automatically adds the `client_id` token-endpoint query parameter, `brk-multihub://m365.cloud.microsoft` redirect URI, and the MSAL browser telemetry fields seen in current Teams requests.
+
 ### Refresh to new access token
 
 If you do not specify a refresh token the cmdlets will use `$response.refresh_token` as a default.
@@ -200,6 +219,12 @@ Only supported user-facing commands are exported; parsing, PKCE, generic refresh
 TokenTactic's methods are highly influenced by the great research of Dr Nestori Syynimaa at https://o365blog.com/.
 
 ## Changelog
+
+### 0.3.1 (2026-07-26)
+
+* Add `Get-EntraIDTokenFromNestedAppAuth` to exchange broker refresh tokens for nested app tokens using NAA / BroCi.
+* Add broker presets for Azure Portal, Teams, Microsoft 365, Entra admin center, Intune admin center, Defender, and Purview, including the newer `teams.cloud.microsoft` broker flow.
+* Add deterministic Pester coverage for the new Nested App Authentication request contracts and export surface.
 
 ### 0.3.0 (2026-07-13)
 

--- a/TokenTactics.psd1
+++ b/TokenTactics.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'TokenTactics.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.3.0'
+    ModuleVersion     = '0.3.1'
     
     # ID used to uniquely identify this module
     GUID              = '6194f0f0-8b91-4c32-b1b1-bc46c9d7a95c'
@@ -27,6 +27,7 @@
         'Get-EntraIDTokenFromAuthorizationCode'
         'Get-EntraIDTokenFromCookie'
         'Get-EntraIDTokenFromESTSCookie'
+        'Get-EntraIDTokenFromNestedAppAuth'
         'Get-EntraIDTokenFromRefreshTokenCredentialCookie'
         'Get-EntraIDTokenFromSCCAUTHCookie'
         'Get-ForgedUserAgent'

--- a/TokenTactics.psm1
+++ b/TokenTactics.psm1
@@ -46,6 +46,7 @@ $functions = @(
     "Get-EntraIDTokenFromAuthorizationCode"
     "Get-EntraIDTokenFromCookie"
     "Get-EntraIDTokenFromESTSCookie"
+    "Get-EntraIDTokenFromNestedAppAuth"
     "Get-EntraIDTokenFromRefreshTokenCredentialCookie"
     "Get-EntraIDTokenFromSCCAUTHCookie"
     "Get-ForgedUserAgent"

--- a/modules/Get-EntraIDTokenFromNestedAppAuth.ps1
+++ b/modules/Get-EntraIDTokenFromNestedAppAuth.ps1
@@ -1,0 +1,233 @@
+function Get-EntraIDTokenFromNestedAppAuth {
+    <#
+    .DESCRIPTION
+        Exchange a broker application's refresh token for a nested application's token using
+        Nested App Authentication (NAA / BroCi).
+
+        The default values target the Azure Portal broker and the ADIbizaUX nested client,
+        but all broker and client settings can be overridden.
+
+    .EXAMPLE
+        Get-EntraIDTokenFromNestedAppAuth -TenantId "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" -RefreshToken $response.refresh_token
+
+    .AUTHOR
+        Fabian Bader
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $False)]
+        [string]$RefreshToken = $response.refresh_token,
+        [Parameter(Mandatory = $False)]
+        [string]$TenantId = "common",
+        [Parameter(Mandatory = $False)]
+        [string]$Domain,
+        [Parameter(Mandatory = $False)]
+        [string]$AuthorityHost = "login.microsoftonline.com",
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('AzurePortal', 'Teams', 'Microsoft365', 'EntraAdminCenter', 'IntuneAdminCenter', 'Defender', 'Purview')]
+        [string]$BrokerPreset,
+        [Parameter(Mandatory = $False)]
+        [string]$BrokerClientId = "c44b4083-3bb0-49c1-b47d-974e53cbdf3c",
+        [Parameter(Mandatory = $False)]
+        [string]$BrokerRedirectUri = "https://portal.azure.com/auth/redirect/",
+        [Parameter(Mandatory = $False)]
+        [string]$ClientId = "74658136-14ec-4630-ad9b-26e160ff0fc6",
+        [Parameter(Mandatory = $False)]
+        [string]$Scope = "https://graph.microsoft.com/.default openid profile offline_access",
+        [Parameter(Mandatory = $False)]
+        [string]$RedirectUri,
+        [Parameter(Mandatory = $False)]
+        [string]$CustomUserAgent,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Mac', 'Windows', 'AndroidMobile', 'iPhone')]
+        [string]$Device,
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Android', 'IE', 'Chrome', 'Firefox', 'Edge', 'Safari')]
+        [string]$Browser,
+        [Parameter(Mandatory = $False)]
+        [string]$ClientRequestId = ([System.Guid]::NewGuid().ToString()),
+        [Parameter(Mandatory = $False)]
+        [string]$ClientInfo = "1",
+        [Parameter(Mandatory = $False)]
+        [string]$XClientSku = "msal.js.browser",
+        [Parameter(Mandatory = $False)]
+        [string]$XClientVer = "5.13.0",
+        [Parameter(Mandatory = $False)]
+        [string]$XMsLibCapability = "retry-after, h429",
+        [Parameter(Mandatory = $False)]
+        [string]$XClientCurrentTelemetry,
+        [Parameter(Mandatory = $False)]
+        [string]$XClientLastTelemetry,
+        [Parameter(Mandatory = $False)]
+        [switch]$IncludeClientIdInQuery,
+        [Alias("XAnchorMailbox")]
+        [Parameter(Mandatory = $False)]
+        [string]$AnchorMailbox,
+        [Parameter(Mandatory = $False)]
+        [string]$Claims,
+        [Parameter(Mandatory = $False)]
+        [switch]$UseCAE
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RefreshToken)) {
+        Write-Error "RefreshToken must be provided or `$response.refresh_token must be populated"
+        return
+    }
+
+    $BrokerPresets = @{
+        "AzurePortal" = @{
+            BrokerClientId    = "c44b4083-3bb0-49c1-b47d-974e53cbdf3c"
+            BrokerRedirectUri = "https://portal.azure.com/auth/redirect/"
+        }
+        "Teams" = @{
+            BrokerClientId          = "5e3ce6c0-2b1f-4285-8d4b-75ee78787346"
+            BrokerRedirectUri       = "https://teams.cloud.microsoft/v2/authv2"
+            RedirectUri             = "brk-multihub://m365.cloud.microsoft"
+            IncludeClientIdInQuery  = $true
+            XClientVer              = "5.6.3"
+            XClientCurrentTelemetry = "5|61,0,,,,|,"
+            XClientLastTelemetry    = "5|0||||0,0"
+        }
+        "Microsoft365" = @{
+            BrokerClientId    = "4765445b-32c6-49b0-83e6-1d93765276ca"
+            BrokerRedirectUri = "https://www.microsoft365.com/spalanding"
+        }
+        "EntraAdminCenter" = @{
+            BrokerClientId    = "c44b4083-3bb0-49c1-b47d-974e53cbdf3c"
+            BrokerRedirectUri = "https://entra.microsoft.com/auth/login/"
+        }
+        "IntuneAdminCenter" = @{
+            BrokerClientId    = "c44b4083-3bb0-49c1-b47d-974e53cbdf3c"
+            BrokerRedirectUri = "https://intune.microsoft.com/auth/login/"
+        }
+        "Defender" = @{
+            BrokerClientId    = "80ccca67-54bd-44ab-8625-4b79c4dc7775"
+            BrokerRedirectUri = "https://security.microsoft.com/Blank"
+        }
+        "Purview" = @{
+            BrokerClientId    = "80ccca67-54bd-44ab-8625-4b79c4dc7775"
+            BrokerRedirectUri = "https://purview.microsoft.com/Blank"
+        }
+    }
+
+    if ($PSBoundParameters.ContainsKey('BrokerPreset')) {
+        $SelectedBrokerPreset = $BrokerPresets[$BrokerPreset]
+        if (-not $PSBoundParameters.ContainsKey('BrokerClientId')) {
+            $BrokerClientId = $SelectedBrokerPreset.BrokerClientId
+        }
+        if (-not $PSBoundParameters.ContainsKey('BrokerRedirectUri')) {
+            $BrokerRedirectUri = $SelectedBrokerPreset.BrokerRedirectUri
+        }
+        if ($SelectedBrokerPreset.ContainsKey('RedirectUri') -and -not $PSBoundParameters.ContainsKey('RedirectUri')) {
+            $RedirectUri = $SelectedBrokerPreset.RedirectUri
+        }
+        if ($SelectedBrokerPreset.ContainsKey('XClientVer') -and -not $PSBoundParameters.ContainsKey('XClientVer')) {
+            $XClientVer = $SelectedBrokerPreset.XClientVer
+        }
+        if ($SelectedBrokerPreset.ContainsKey('XClientCurrentTelemetry') -and -not $PSBoundParameters.ContainsKey('XClientCurrentTelemetry')) {
+            $XClientCurrentTelemetry = $SelectedBrokerPreset.XClientCurrentTelemetry
+        }
+        if ($SelectedBrokerPreset.ContainsKey('XClientLastTelemetry') -and -not $PSBoundParameters.ContainsKey('XClientLastTelemetry')) {
+            $XClientLastTelemetry = $SelectedBrokerPreset.XClientLastTelemetry
+        }
+        Write-Verbose "Using broker preset $BrokerPreset"
+    }
+
+    $ShouldIncludeClientIdInQuery = $IncludeClientIdInQuery.IsPresent
+    if ($PSBoundParameters.ContainsKey('BrokerPreset') -and $BrokerPreset -eq 'Teams') {
+        $ShouldIncludeClientIdInQuery = $true
+    }
+
+    if ($PSBoundParameters.ContainsKey('Domain')) {
+        $TenantId = Get-TenantID -domain $Domain
+        Write-Verbose "Resolved tenant ID from domain $Domain`: $TenantId"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Claims) -and $UseCAE) {
+        # Add 'cp1' as client claim to get a CAE-capable access token.
+        $Claims = ( @{"access_token" = @{ "xms_cc" = @{ "values" = @("cp1") } } } | ConvertTo-Json -Compress -Depth 99 )
+    }
+
+    if ($CustomUserAgent) {
+        $UserAgent = $CustomUserAgent
+    } elseif ($Device) {
+        if ($Browser) {
+            $UserAgent = Get-ForgedUserAgent -Device $Device -Browser $Browser
+        } else {
+            $UserAgent = Get-ForgedUserAgent -Device $Device
+        }
+    } elseif ($Browser) {
+        $UserAgent = Get-ForgedUserAgent -Browser $Browser
+    } else {
+        $UserAgent = Get-ForgedUserAgent
+    }
+
+    if ([string]::IsNullOrWhiteSpace($RedirectUri)) {
+        try {
+            $BrokerRedirectUriObject = [System.Uri]$BrokerRedirectUri
+        } catch {
+            Write-Error "Invalid BrokerRedirectUri format. $($_.Exception.Message)"
+            return
+        }
+
+        $BrokerAuthority = $BrokerRedirectUriObject.GetLeftPart([System.UriPartial]::Authority)
+        if ([string]::IsNullOrWhiteSpace($BrokerAuthority)) {
+            Write-Error "BrokerRedirectUri must contain a valid authority"
+            return
+        }
+        $RedirectUri = "brk-${BrokerClientId}://$($BrokerAuthority -replace '^https?://', '')"
+    }
+
+    $Headers = @{}
+    $Headers["User-Agent"] = $UserAgent
+
+    $TokenEndpointQueryParameters = [System.Collections.Generic.List[string]]::new()
+    if ($ShouldIncludeClientIdInQuery) {
+        $TokenEndpointQueryParameters.Add("client_id=$([System.Uri]::EscapeDataString($ClientId))")
+    }
+    $TokenEndpointQueryParameters.Add("brk_client_id=$([System.Uri]::EscapeDataString($BrokerClientId))")
+    $TokenEndpointQueryParameters.Add("brk_redirect_uri=$([System.Uri]::EscapeDataString($BrokerRedirectUri))")
+    $TokenEndpointQueryParameters.Add("client-request-id=$([System.Uri]::EscapeDataString($ClientRequestId))")
+    $TokenEndpointUri = "https://$AuthorityHost/$TenantId/oauth2/v2.0/token?" + ($TokenEndpointQueryParameters -join '&')
+
+    $body = @{
+        "client_id"           = $ClientId
+        "redirect_uri"        = $RedirectUri
+        "scope"               = $Scope
+        "grant_type"          = "refresh_token"
+        "client_info"         = $ClientInfo
+        "x-client-SKU"        = $XClientSku
+        "x-client-VER"        = $XClientVer
+        "x-ms-lib-capability" = $XMsLibCapability
+        "refresh_token"       = $RefreshToken
+        "brk_client_id"       = $BrokerClientId
+        "brk_redirect_uri"    = $BrokerRedirectUri
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($AnchorMailbox)) {
+        $body.Add("X-AnchorMailbox", $AnchorMailbox)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Claims)) {
+        $body.Add("claims", $Claims)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($XClientCurrentTelemetry)) {
+        $body.Add("x-client-current-telemetry", $XClientCurrentTelemetry)
+    }
+    if (-not [string]::IsNullOrWhiteSpace($XClientLastTelemetry)) {
+        $body.Add("x-client-last-telemetry", $XClientLastTelemetry)
+    }
+
+    Write-Verbose "Calling brokered token endpoint"
+    Write-Verbose "URI: $TokenEndpointUri"
+    Write-Verbose ($body | ConvertTo-Json -Depth 99)
+
+    try {
+        $global:response = Invoke-RestMethod -UseBasicParsing -Method Post -Uri $TokenEndpointUri -Headers $Headers -Body $body
+        $output = ConvertFrom-JWTtoken -token $response.access_token
+        $global:TokenDomain = $output.upn -split '@' | Select-Object -Last 1
+        $global:TokenUpn = $output.upn
+        Write-Output "$([char]0x2713)  Token acquired and saved as `$response"
+    } catch {
+        Write-Error "Could not get tokens $(Get-EntraErrorDescription -ErrorRecord $_)"
+    }
+}

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -11,6 +11,7 @@ BeforeAll {
         'Get-EntraIDTokenFromAuthorizationCode'
         'Get-EntraIDTokenFromCookie'
         'Get-EntraIDTokenFromESTSCookie'
+        'Get-EntraIDTokenFromNestedAppAuth'
         'Get-EntraIDTokenFromRefreshTokenCredentialCookie'
         'Get-EntraIDTokenFromSCCAUTHCookie'
         'Get-ForgedUserAgent'

--- a/tests/TokenHandler.Tests.ps1
+++ b/tests/TokenHandler.Tests.ps1
@@ -631,3 +631,268 @@ Describe "Get-EntraIDTokenFromAuthorizationCode" {
         $global:TokenUpn | Should -Be "test.user@contoso.com"
     }
 }
+
+# ---------------------------------------------------------------------------
+# Get-EntraIDTokenFromNestedAppAuth
+# ---------------------------------------------------------------------------
+Describe "Get-EntraIDTokenFromNestedAppAuth" {
+    $brokerPresetCases = @(
+        @{
+            BrokerPreset      = 'AzurePortal'
+            BrokerClientId    = 'c44b4083-3bb0-49c1-b47d-974e53cbdf3c'
+            BrokerRedirectUri = 'https://portal.azure.com/auth/redirect/'
+            RedirectUri       = 'brk-c44b4083-3bb0-49c1-b47d-974e53cbdf3c://portal.azure.com'
+        }
+        @{
+            BrokerPreset      = 'Microsoft365'
+            BrokerClientId    = '4765445b-32c6-49b0-83e6-1d93765276ca'
+            BrokerRedirectUri = 'https://www.microsoft365.com/spalanding'
+            RedirectUri       = 'brk-4765445b-32c6-49b0-83e6-1d93765276ca://www.microsoft365.com'
+        }
+        @{
+            BrokerPreset      = 'EntraAdminCenter'
+            BrokerClientId    = 'c44b4083-3bb0-49c1-b47d-974e53cbdf3c'
+            BrokerRedirectUri = 'https://entra.microsoft.com/auth/login/'
+            RedirectUri       = 'brk-c44b4083-3bb0-49c1-b47d-974e53cbdf3c://entra.microsoft.com'
+        }
+        @{
+            BrokerPreset      = 'IntuneAdminCenter'
+            BrokerClientId    = 'c44b4083-3bb0-49c1-b47d-974e53cbdf3c'
+            BrokerRedirectUri = 'https://intune.microsoft.com/auth/login/'
+            RedirectUri       = 'brk-c44b4083-3bb0-49c1-b47d-974e53cbdf3c://intune.microsoft.com'
+        }
+        @{
+            BrokerPreset      = 'Defender'
+            BrokerClientId    = '80ccca67-54bd-44ab-8625-4b79c4dc7775'
+            BrokerRedirectUri = 'https://security.microsoft.com/Blank'
+            RedirectUri       = 'brk-80ccca67-54bd-44ab-8625-4b79c4dc7775://security.microsoft.com'
+        }
+        @{
+            BrokerPreset      = 'Purview'
+            BrokerClientId    = '80ccca67-54bd-44ab-8625-4b79c4dc7775'
+            BrokerRedirectUri = 'https://purview.microsoft.com/Blank'
+            RedirectUri       = 'brk-80ccca67-54bd-44ab-8625-4b79c4dc7775://purview.microsoft.com'
+        }
+    )
+
+    BeforeEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw "Unexpected REST request: $Method $Uri" }
+        Mock -ModuleName TokenTactics Get-TenantID { return $script:FakeTenantId }
+    }
+
+    AfterEach {
+        foreach ($name in 'response', 'TokenDomain', 'TokenUpn') {
+            Remove-Variable -Scope Global -Name $name -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "sends the exact Azure Portal brokered token request with CAE claims" {
+        $brokerClientId = 'c44b4083-3bb0-49c1-b47d-974e53cbdf3c'
+        $brokerRedirectUri = 'https://portal.azure.com/auth/redirect/'
+        $clientRequestId = '11111111-2222-3333-4444-555555555555'
+        $anchorMailbox = "Oid:3135fd4e-140c-43c0-ad02-718913648fb9@$($script:FakeTenantId)"
+        $claims = '{"access_token":{"xms_cc":{"values":["cp1"]}}}'
+
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $script:FakeTokenResponse } -ParameterFilter {
+            $parsedUri = [Uri]$Uri
+            $query = [System.Web.HttpUtility]::ParseQueryString($parsedUri.Query)
+
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            $parsedUri.Scheme -eq 'https' -and
+            $parsedUri.Host -eq 'login.microsoftonline.com' -and
+            $parsedUri.AbsolutePath -eq "/$script:FakeTenantId/oauth2/v2.0/token" -and
+            $Headers -is [System.Collections.IDictionary] -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'Nested-Agent/1.0' -and
+            $query.Count -eq 3 -and
+            $query['brk_client_id'] -eq $brokerClientId -and
+            $query['brk_redirect_uri'] -eq $brokerRedirectUri -and
+            $query['client-request-id'] -eq $clientRequestId -and
+            $Body -is [System.Collections.IDictionary] -and
+            $Body.Count -eq 13 -and
+            $Body['client_id'] -eq '74658136-14ec-4630-ad9b-26e160ff0fc6' -and
+            $Body['redirect_uri'] -eq 'brk-c44b4083-3bb0-49c1-b47d-974e53cbdf3c://portal.azure.com' -and
+            $Body['scope'] -eq 'https://graph.microsoft.com/.default openid profile offline_access' -and
+            $Body['grant_type'] -eq 'refresh_token' -and
+            $Body['client_info'] -eq '1' -and
+            $Body['x-client-SKU'] -eq 'msal.js.browser' -and
+            $Body['x-client-VER'] -eq '5.13.0' -and
+            $Body['x-ms-lib-capability'] -eq 'retry-after, h429' -and
+            $Body['refresh_token'] -eq 'nested-app-refresh-token' -and
+            $Body['brk_client_id'] -eq $brokerClientId -and
+            $Body['brk_redirect_uri'] -eq $brokerRedirectUri -and
+            $Body['X-AnchorMailbox'] -eq $anchorMailbox -and
+            $Body['claims'] -eq $claims
+        }
+
+        Get-EntraIDTokenFromNestedAppAuth `
+            -TenantId $script:FakeTenantId `
+            -RefreshToken 'nested-app-refresh-token' `
+            -CustomUserAgent 'Nested-Agent/1.0' `
+            -ClientRequestId $clientRequestId `
+            -AnchorMailbox $anchorMailbox `
+            -UseCAE
+
+        $global:response | Should -Be $script:FakeTokenResponse
+        $global:TokenDomain | Should -Be 'contoso.com'
+        $global:TokenUpn | Should -Be 'test.user@contoso.com'
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It
+    }
+
+    It "matches the Teams Cloud brokered request shape for the provided example" {
+        $brokerClientId = '5e3ce6c0-2b1f-4285-8d4b-75ee78787346'
+        $brokerRedirectUri = 'https://teams.cloud.microsoft/v2/authv2'
+        $clientRequestId = '019f9eab-d509-781d-8e67-1ca76d834633'
+        $anchorMailbox = "Oid:e7417ac7-0485-4014-9100-33163bd6211f@$($script:FakeTenantId)"
+        $clientId = '4765445b-32c6-49b0-83e6-1d93765276ca'
+        $scope = '4765445b-32c6-49b0-83e6-1d93765276ca/.default openid profile offline_access'
+
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $script:FakeTokenResponse } -ParameterFilter {
+            $parsedUri = [Uri]$Uri
+            $query = [System.Web.HttpUtility]::ParseQueryString($parsedUri.Query)
+
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            $parsedUri.Scheme -eq 'https' -and
+            $parsedUri.Host -eq 'login.microsoftonline.com' -and
+            $parsedUri.AbsolutePath -eq "/$script:FakeTenantId/oauth2/v2.0/token" -and
+            $Headers -is [System.Collections.IDictionary] -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'Nested-Agent/Teams' -and
+            $query.Count -eq 4 -and
+            $query['client_id'] -eq $clientId -and
+            $query['brk_client_id'] -eq $brokerClientId -and
+            $query['brk_redirect_uri'] -eq $brokerRedirectUri -and
+            $query['client-request-id'] -eq $clientRequestId -and
+            $Body -is [System.Collections.IDictionary] -and
+            $Body.Count -eq 14 -and
+            $Body['client_id'] -eq $clientId -and
+            $Body['redirect_uri'] -eq 'brk-multihub://m365.cloud.microsoft' -and
+            $Body['scope'] -eq $scope -and
+            $Body['grant_type'] -eq 'refresh_token' -and
+            $Body['client_info'] -eq '1' -and
+            $Body['x-client-SKU'] -eq 'msal.js.browser' -and
+            $Body['x-client-VER'] -eq '5.6.3' -and
+            $Body['x-ms-lib-capability'] -eq 'retry-after, h429' -and
+            $Body['x-client-current-telemetry'] -eq '5|61,0,,,,|,' -and
+            $Body['x-client-last-telemetry'] -eq '5|0||||0,0' -and
+            $Body['refresh_token'] -eq 'teams-refresh-token' -and
+            $Body['X-AnchorMailbox'] -eq $anchorMailbox -and
+            $Body['brk_client_id'] -eq $brokerClientId -and
+            $Body['brk_redirect_uri'] -eq $brokerRedirectUri
+        }
+
+        Get-EntraIDTokenFromNestedAppAuth `
+            -BrokerPreset Teams `
+            -TenantId $script:FakeTenantId `
+            -RefreshToken 'teams-refresh-token' `
+            -ClientId $clientId `
+            -Scope $scope `
+            -ClientRequestId $clientRequestId `
+            -AnchorMailbox $anchorMailbox `
+            -CustomUserAgent 'Nested-Agent/Teams'
+
+        $global:response | Should -Be $script:FakeTokenResponse
+        $global:TokenDomain | Should -Be 'contoso.com'
+        $global:TokenUpn | Should -Be 'test.user@contoso.com'
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It
+    }
+
+    It "maps the <BrokerPreset> broker preset to the expected broker values" -ForEach $brokerPresetCases {
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $script:FakeTokenResponse } -ParameterFilter {
+            $parsedUri = [Uri]$Uri
+            $query = [System.Web.HttpUtility]::ParseQueryString($parsedUri.Query)
+
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            $parsedUri.Scheme -eq 'https' -and
+            $parsedUri.Host -eq 'login.microsoftonline.com' -and
+            $parsedUri.AbsolutePath -eq "/$script:FakeTenantId/oauth2/v2.0/token" -and
+            $Headers -is [System.Collections.IDictionary] -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'Nested-Agent/Preset' -and
+            $query['brk_client_id'] -eq $BrokerClientId -and
+            $query['brk_redirect_uri'] -eq $BrokerRedirectUri -and
+            $Body -is [System.Collections.IDictionary] -and
+            $Body.Count -eq 11 -and
+            $Body['client_id'] -eq 'nested-client-id' -and
+            $Body['redirect_uri'] -eq $RedirectUri -and
+            $Body['scope'] -eq 'api://nested/.default offline_access' -and
+            $Body['grant_type'] -eq 'refresh_token' -and
+            $Body['refresh_token'] -eq 'preset-refresh-token' -and
+            $Body['brk_client_id'] -eq $BrokerClientId -and
+            $Body['brk_redirect_uri'] -eq $BrokerRedirectUri
+        }
+
+        Get-EntraIDTokenFromNestedAppAuth `
+            -BrokerPreset $BrokerPreset `
+            -TenantId $script:FakeTenantId `
+            -RefreshToken 'preset-refresh-token' `
+            -ClientId 'nested-client-id' `
+            -Scope 'api://nested/.default offline_access' `
+            -CustomUserAgent 'Nested-Agent/Preset' `
+            -ClientRequestId '99999999-8888-7777-6666-555555555555'
+
+        $global:response | Should -Be $script:FakeTokenResponse
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It
+    }
+
+    It "uses `$response.refresh_token as a fallback and lets explicit broker overrides win over the preset" {
+        $global:response = [PSCustomObject]@{ refresh_token = 'fallback-refresh-token' }
+        $brokerClientId = '11111111-2222-3333-4444-555555555555'
+        $brokerRedirectUri = 'https://contoso.example/auth/callback/'
+        $clientRequestId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+
+        Mock -ModuleName TokenTactics Invoke-RestMethod { $script:FakeTokenResponse } -ParameterFilter {
+            $parsedUri = [Uri]$Uri
+            $query = [System.Web.HttpUtility]::ParseQueryString($parsedUri.Query)
+
+            $UseBasicParsing -and
+            "$Method" -eq 'Post' -and
+            $parsedUri.Scheme -eq 'https' -and
+            $parsedUri.Host -eq 'login.microsoftonline.com' -and
+            $parsedUri.AbsolutePath -eq "/$script:FakeTenantId/oauth2/v2.0/token" -and
+            $Headers -is [System.Collections.IDictionary] -and
+            $Headers.Count -eq 1 -and
+            $Headers['User-Agent'] -eq 'Nested-Agent/2.0' -and
+            $query.Count -eq 3 -and
+            $query['brk_client_id'] -eq $brokerClientId -and
+            $query['brk_redirect_uri'] -eq $brokerRedirectUri -and
+            $query['client-request-id'] -eq $clientRequestId -and
+            $Body -is [System.Collections.IDictionary] -and
+            $Body.Count -eq 11 -and
+            $Body['client_id'] -eq 'nested-client-id' -and
+            $Body['redirect_uri'] -eq 'brk-11111111-2222-3333-4444-555555555555://contoso.example' -and
+            $Body['scope'] -eq 'api://nested/.default offline_access' -and
+            $Body['grant_type'] -eq 'refresh_token' -and
+            $Body['client_info'] -eq '1' -and
+            $Body['x-client-SKU'] -eq 'msal.js.browser' -and
+            $Body['x-client-VER'] -eq '5.13.0' -and
+            $Body['x-ms-lib-capability'] -eq 'retry-after, h429' -and
+            $Body['refresh_token'] -eq 'fallback-refresh-token' -and
+            $Body['brk_client_id'] -eq $brokerClientId -and
+            $Body['brk_redirect_uri'] -eq $brokerRedirectUri
+        }
+
+        Get-EntraIDTokenFromNestedAppAuth `
+            -BrokerPreset 'Defender' `
+            -Domain 'contoso.com' `
+            -BrokerClientId $brokerClientId `
+            -BrokerRedirectUri $brokerRedirectUri `
+            -ClientId 'nested-client-id' `
+            -Scope 'api://nested/.default offline_access' `
+            -CustomUserAgent 'Nested-Agent/2.0' `
+            -ClientRequestId $clientRequestId
+
+        $global:response | Should -Be $script:FakeTokenResponse
+        Should -Invoke -ModuleName TokenTactics Get-TenantID -Times 1 -Exactly -Scope It -ParameterFilter {
+            $domain -eq 'contoso.com'
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-RestMethod -Times 1 -Exactly -Scope It
+    }
+}


### PR DESCRIPTION
## Summary
- add `Get-EntraIDTokenFromNestedAppAuth` as a dedicated cmdlet in its own module file
- support broker presets for Azure Portal, Teams, Microsoft365, EntraAdminCenter, IntuneAdminCenter, Defender, and Purview
- align the Teams preset with the newer `teams.cloud.microsoft` broker flow, including query/body telemetry fields
- export the new cmdlet, bump the module version to `0.3.1`, and document the flow in the README
- add deterministic Pester coverage for the new request contracts and export surface

## Testing
- `pwsh ./tests/Invoke-Tests.ps1`