### PR TITLE
feat: add TPM certificate authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ Get-EntraIDTokenFromDeviceCode -Client MSGraph
 
 Once the user has logged in, you'll be presented with the JWT and it will be saved in the `$response` variable. To access the access token use ```$response.access_token``` from your PowerShell window to display the token. You may also display the refresh token with ```$response.refresh_token```. Hint: You'll want the refresh token to keep refreshing to new tokens!
 
+### Authenticate an application with a TPM-backed certificate
+
+> [!IMPORTANT]
+> Creating TPM-backed certificates requires Windows, a provisioned TPM, and the Microsoft Platform Crypto Provider.
+
+Create a non-exportable RSA certificate in your current user's personal store and export only its public certificate. The `.cer` file is DER encoded and can be uploaded under **App registrations > Certificates & secrets > Certificates**. Configure the application permissions required by the target resource and grant tenant admin consent before requesting a token.
+
+```powershell
+$certificate = New-TPMCertificate `
+    -Subject 'CN=EntraID-TPM-Auth' `
+    -PublicKeyPath 'C:\Temp\EntraID-TPM-Auth.cer'
+
+$token = Get-EntraIDTokenFromCertificate `
+    -TenantId 'contoso.onmicrosoft.com' `
+    -ClientId '00000000-0000-0000-0000-000000000000' `
+    -CertificateThumbprint $certificate.Thumbprint `
+    -Scope 'https://graph.microsoft.com/.default'
+```
+
+`Get-EntraIDTokenFromCertificate` returns the OAuth token response and also saves it in `$response`. `New-TPMCertificate` defaults to `Cert:\CurrentUser\My`; use `-CertStoreLocation Cert:\LocalMachine\My` for a service account when the process has the necessary permissions. The TPM private key is deliberately non-exportable; only the public `.cer` file is written to disk.
+
 #### DOD/Mil Device Code
 
 ```powershell
@@ -219,6 +240,11 @@ Only supported user-facing commands are exported; parsing, PKCE, generic refresh
 TokenTactic's methods are highly influenced by the great research of Dr Nestori Syynimaa at https://o365blog.com/.
 
 ## Changelog
+
+### 0.3.3 (2026-08-05)
+
+* Add `New-TPMCertificate` for creating non-exportable, Windows TPM-backed RSA certificates and optionally exporting their public DER certificate.
+* Add `Get-EntraIDTokenFromCertificate` to request Entra ID application tokens through OAuth 2.0 client credentials with an RS256 certificate assertion.
 
 ### 0.3.2 (2026-07-26)
 

--- a/TokenTactics.psd1
+++ b/TokenTactics.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'TokenTactics.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.3.2'
+    ModuleVersion     = '0.3.3'
     
     # ID used to uniquely identify this module
     GUID              = '6194f0f0-8b91-4c32-b1b1-bc46c9d7a95c'
@@ -23,6 +23,7 @@
         'ConvertFrom-JWTtoken'
         'ConvertTo-PEMPrivateKey'
         'Get-EntraIDAuthorizationCode'
+        'Get-EntraIDTokenFromCertificate'
         'Get-EntraIDTokenFromDeviceCode'
         'Get-EntraIDTokenFromAuthorizationCode'
         'Get-EntraIDTokenFromCookie'
@@ -51,6 +52,7 @@
         'Invoke-RefreshToSharePointToken'
         'Invoke-RefreshToSubstrateToken'
         'Invoke-RefreshToYammerToken'
+        'New-TPMCertificate'
     )
 
     AliasesToExport = @(

--- a/TokenTactics.psm1
+++ b/TokenTactics.psm1
@@ -42,6 +42,7 @@ $functions = @(
     "ConvertFrom-JWTtoken"
     "ConvertTo-PEMPrivateKey"
     "Get-EntraIDAuthorizationCode"
+    "Get-EntraIDTokenFromCertificate"
     "Get-EntraIDTokenFromDeviceCode"
     "Get-EntraIDTokenFromAuthorizationCode"
     "Get-EntraIDTokenFromCookie"
@@ -70,6 +71,7 @@ $functions = @(
     "Invoke-RefreshToSharePointToken"
     "Invoke-RefreshToSubstrateToken"
     "Invoke-RefreshToYammerToken"
+    "New-TPMCertificate"
 )
 
 $c = 0

--- a/modules/Get-EntraIDTokenFromCertificate.ps1
+++ b/modules/Get-EntraIDTokenFromCertificate.ps1
@@ -1,0 +1,138 @@
+function Get-EntraIDTokenFromCertificate {
+    <#
+    .SYNOPSIS
+        Acquires an Entra ID application token with a certificate client assertion.
+
+    .DESCRIPTION
+        Resolves an RSA certificate from a Windows personal certificate store, signs
+        an RS256 client assertion with its private key, and exchanges that assertion
+        through the OAuth 2.0 client credentials flow. TPM-backed certificates sign
+        through the Microsoft Platform Crypto Provider without exporting their key.
+
+    .PARAMETER TenantId
+        The Microsoft Entra tenant ID or domain.
+
+    .PARAMETER ClientId
+        The application (client) ID registered in Microsoft Entra ID.
+
+    .PARAMETER CertificateThumbprint
+        The thumbprint of the certificate registered on the application.
+
+    .PARAMETER Scope
+        The application permission scope to request. This must use the .default suffix.
+
+    .PARAMETER CertStoreLocation
+        The personal certificate store containing the certificate.
+
+    .EXAMPLE
+        Get-EntraIDTokenFromCertificate `
+            -TenantId 'contoso.onmicrosoft.com' `
+            -ClientId '00000000-0000-0000-0000-000000000000' `
+            -CertificateThumbprint '0123456789ABCDEF0123456789ABCDEF01234567'
+
+    .NOTES
+        Upload the corresponding public .cer file to the Entra ID App Registration
+        before requesting a token.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$TenantId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ClientId,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$CertificateThumbprint,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Scope = 'https://graph.microsoft.com/.default',
+
+        [Parameter()]
+        [ValidateSet('Cert:\CurrentUser\My', 'Cert:\LocalMachine\My')]
+        [string]$CertStoreLocation = 'Cert:\CurrentUser\My'
+    )
+
+    if ($env:OS -ne 'Windows_NT') {
+        throw 'Get-EntraIDTokenFromCertificate requires a Windows certificate store.'
+    }
+
+    $normalizedThumbprint = ($CertificateThumbprint -replace '\s', '').ToUpperInvariant()
+    if ($normalizedThumbprint.Length % 2 -ne 0 -or $normalizedThumbprint -notmatch '^[0-9A-F]+$') {
+        throw "Certificate thumbprint '$CertificateThumbprint' is not valid hexadecimal."
+    }
+
+    $certificatePath = "$CertStoreLocation\$normalizedThumbprint"
+    try {
+        $certificate = Get-Item -Path $certificatePath -ErrorAction Stop
+    } catch {
+        throw "Certificate '$normalizedThumbprint' was not found at '$CertStoreLocation'. $($_.Exception.Message)"
+    }
+
+    $now = [DateTimeOffset]::UtcNow
+    if ($certificate.NotBefore.ToUniversalTime() -gt $now.UtcDateTime -or $certificate.NotAfter.ToUniversalTime() -lt $now.UtcDateTime) {
+        throw "Certificate '$normalizedThumbprint' is not currently valid."
+    }
+    if (-not $certificate.HasPrivateKey) {
+        throw "Certificate '$normalizedThumbprint' does not have an accessible private key."
+    }
+
+    try {
+        $rsa = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($certificate)
+    } catch {
+        throw "Certificate '$normalizedThumbprint' does not expose an RSA private key. $($_.Exception.Message)"
+    }
+
+    if ($null -eq $rsa) {
+        throw "Certificate '$normalizedThumbprint' does not expose an RSA private key."
+    }
+
+    try {
+        $thumbprintBytes = [byte[]]::new($normalizedThumbprint.Length / 2)
+        for ($index = 0; $index -lt $normalizedThumbprint.Length; $index += 2) {
+            $thumbprintBytes[$index / 2] = [Convert]::ToByte($normalizedThumbprint.Substring($index, 2), 16)
+        }
+
+        $tokenEndpoint = "https://login.microsoftonline.com/$TenantId/oauth2/v2.0/token"
+        $header = [ordered]@{
+            alg = 'RS256'
+            typ = 'JWT'
+            x5t = ConvertTo-Base64Url -Bytes $thumbprintBytes
+        }
+        $payload = [ordered]@{
+            aud = $tokenEndpoint
+            iss = $ClientId
+            sub = $ClientId
+            jti = [guid]::NewGuid().ToString()
+            nbf = $now.ToUnixTimeSeconds()
+            exp = $now.AddMinutes(10).ToUnixTimeSeconds()
+        }
+
+        $headerBytes = [System.Text.Encoding]::UTF8.GetBytes(($header | ConvertTo-Json -Compress))
+        $payloadBytes = [System.Text.Encoding]::UTF8.GetBytes(($payload | ConvertTo-Json -Compress))
+        $unsignedAssertion = "$(ConvertTo-Base64Url -Bytes $headerBytes).$(ConvertTo-Base64Url -Bytes $payloadBytes)"
+        $signature = $rsa.SignData(
+            [System.Text.Encoding]::UTF8.GetBytes($unsignedAssertion),
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+            [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+        )
+        $clientAssertion = "$unsignedAssertion.$(ConvertTo-Base64Url -Bytes $signature)"
+
+        $body = @{
+            client_id             = $ClientId
+            scope                 = $Scope
+            client_assertion_type = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+            client_assertion      = $clientAssertion
+            grant_type            = 'client_credentials'
+        }
+
+        $global:response = Invoke-RestMethod -UseBasicParsing -Method Post -Uri $tokenEndpoint -Body $body -ErrorAction Stop
+        Write-Output $global:response
+    } finally {
+        $rsa.Dispose()
+    }
+}

--- a/modules/New-TPMCertificate.ps1
+++ b/modules/New-TPMCertificate.ps1
@@ -1,0 +1,96 @@
+function New-TPMCertificate {
+    <#
+    .SYNOPSIS
+        Creates a non-exportable RSA certificate backed by the Windows TPM.
+
+    .DESCRIPTION
+        Creates a self-signed certificate in a personal certificate store using the
+        Microsoft Platform Crypto Provider. The private key remains non-exportable
+        and can be used to authenticate an Entra ID application with a certificate.
+
+    .PARAMETER Subject
+        The subject distinguished name for the certificate.
+
+    .PARAMETER CertStoreLocation
+        The personal certificate store in which to create the certificate.
+
+    .PARAMETER PublicKeyPath
+        Optional path to write the public certificate as a DER-encoded .cer file.
+
+    .EXAMPLE
+        New-TPMCertificate -Subject 'CN=EntraID-TPM-Auth' -PublicKeyPath C:\Temp\EntraID-TPM-Auth.cer
+
+    .EXAMPLE
+        New-TPMCertificate -Subject 'CN=Service-Auth' -CertStoreLocation Cert:\LocalMachine\My
+
+    .NOTES
+        This command requires Windows, a provisioned TPM, and the Microsoft Platform
+        Crypto Provider. A LocalMachine certificate store generally requires elevation.
+    #>
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Subject,
+
+        [Parameter()]
+        [ValidateSet('Cert:\CurrentUser\My', 'Cert:\LocalMachine\My')]
+        [string]$CertStoreLocation = 'Cert:\CurrentUser\My',
+
+        [Parameter()]
+        [ValidateSet(2048, 3072, 4096)]
+        [int]$KeyLength = 2048,
+
+        [Parameter()]
+        [ValidateScript({ $_ -gt (Get-Date) })]
+        [datetime]$NotAfter = (Get-Date).AddYears(2),
+
+        [Parameter()]
+        [ValidatePattern('(?i)\.cer$')]
+        [string]$PublicKeyPath
+    )
+
+    if ($env:OS -ne 'Windows_NT') {
+        throw 'New-TPMCertificate is supported only on Windows.'
+    }
+
+    if (-not (Get-Command -Name New-SelfSignedCertificate -ErrorAction SilentlyContinue)) {
+        throw 'The Windows PKI New-SelfSignedCertificate cmdlet is unavailable.'
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($CertStoreLocation, "Create TPM-backed certificate '$Subject'")) {
+        return
+    }
+
+    $certificateParameters = @{
+        Subject           = $Subject
+        CertStoreLocation = $CertStoreLocation
+        Provider          = 'Microsoft Platform Crypto Provider'
+        KeyAlgorithm      = 'RSA'
+        KeyLength         = $KeyLength
+        KeyUsage          = 'DigitalSignature'
+        KeyExportPolicy   = 'NonExportable'
+        NotAfter          = $NotAfter
+        ErrorAction       = 'Stop'
+    }
+
+    $certificate = New-SelfSignedCertificate @certificateParameters
+
+    if ($PublicKeyPath) {
+        Export-TTPublicCertificate -Certificate $certificate -Path $PublicKeyPath
+    }
+
+    Write-Output $certificate
+}
+
+function Export-TTPublicCertificate {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Certificate,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    Export-Certificate -Cert $Certificate -FilePath $Path -Type CERT -ErrorAction Stop | Out-Null
+}

--- a/tests/Get-EntraIDTokenFromCertificate.Tests.ps1
+++ b/tests/Get-EntraIDTokenFromCertificate.Tests.ps1
@@ -1,0 +1,163 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+
+    $script:OriginalOS = $env:OS
+    $env:OS = 'Windows_NT'
+    $script:PrivateKey = [System.Security.Cryptography.RSA]::Create(2048)
+    $request = [System.Security.Cryptography.X509Certificates.CertificateRequest]::new(
+        'CN=TokenTactics-Test',
+        $script:PrivateKey,
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+        [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+    )
+    $script:Certificate = $request.CreateSelfSigned(
+        [DateTimeOffset]::UtcNow.AddMinutes(-1),
+        [DateTimeOffset]::UtcNow.AddMinutes(30)
+    )
+    $script:TokenResponse = [PSCustomObject]@{
+        access_token = $script:FakeAccessToken
+        token_type   = 'Bearer'
+        expires_in   = 3600
+    }
+    $script:ConvertFromTestBase64Url = {
+        param([string]$Value)
+
+        $base64 = $Value.Replace('-', '+').Replace('_', '/')
+        switch ($base64.Length % 4) {
+            2 { $base64 += '==' }
+            3 { $base64 += '=' }
+        }
+
+        [Convert]::FromBase64String($base64)
+    }
+}
+
+AfterAll {
+    $script:Certificate.Dispose()
+    $script:PrivateKey.Dispose()
+    $env:OS = $script:OriginalOS
+}
+
+Describe 'Get-EntraIDTokenFromCertificate' {
+    BeforeEach {
+        $script:LastTokenRequest = $null
+        Mock -ModuleName TokenTactics Get-Item { $script:Certificate }
+        Mock -ModuleName TokenTactics Invoke-RestMethod {
+            $script:LastTokenRequest = @{
+                Method = $Method
+                Uri    = $Uri
+                Body   = $Body
+            }
+            $script:TokenResponse
+        }
+    }
+
+    AfterEach {
+        Remove-Variable -Scope Global -Name response -ErrorAction SilentlyContinue
+    }
+
+    It 'returns and stores the token response' {
+        $result = Get-EntraIDTokenFromCertificate `
+            -TenantId 'contoso.onmicrosoft.com' `
+            -ClientId '11111111-2222-3333-4444-555555555555' `
+            -CertificateThumbprint $script:Certificate.Thumbprint
+
+        $result | Should -Be $script:TokenResponse
+        $global:response | Should -Be $script:TokenResponse
+    }
+
+    It 'sends a signed client-credentials request to the tenant v2 endpoint' {
+        $clientId = '11111111-2222-3333-4444-555555555555'
+        $scope = 'api://token-tactics/.default'
+        Get-EntraIDTokenFromCertificate `
+            -TenantId 'contoso.onmicrosoft.com' `
+            -ClientId $clientId `
+            -CertificateThumbprint $script:Certificate.Thumbprint `
+            -Scope $scope | Out-Null
+
+        $script:LastTokenRequest.Method | Should -Be 'Post'
+        $script:LastTokenRequest.Uri | Should -Be 'https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/token'
+        $script:LastTokenRequest.Body['client_id'] | Should -Be $clientId
+        $script:LastTokenRequest.Body['scope'] | Should -Be $scope
+        $script:LastTokenRequest.Body['grant_type'] | Should -Be 'client_credentials'
+        $script:LastTokenRequest.Body['client_assertion_type'] |
+            Should -Be 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+    }
+
+    It 'builds an RS256 assertion with the certificate thumbprint and valid signature' {
+        $clientId = '11111111-2222-3333-4444-555555555555'
+        Get-EntraIDTokenFromCertificate `
+            -TenantId 'contoso.onmicrosoft.com' `
+            -ClientId $clientId `
+            -CertificateThumbprint $script:Certificate.Thumbprint | Out-Null
+
+        $parts = $script:LastTokenRequest.Body['client_assertion'].Split('.')
+        $parts.Count | Should -Be 3
+        $header = [System.Text.Encoding]::UTF8.GetString((& $script:ConvertFromTestBase64Url -Value $parts[0])) | ConvertFrom-Json
+        $payload = [System.Text.Encoding]::UTF8.GetString((& $script:ConvertFromTestBase64Url -Value $parts[1])) | ConvertFrom-Json
+
+        $header.alg | Should -Be 'RS256'
+        $header.typ | Should -Be 'JWT'
+        $header.x5t | Should -Be ([Convert]::ToBase64String($script:Certificate.GetCertHash()).Replace('+', '-').Replace('/', '_').TrimEnd('='))
+        $payload.aud | Should -Be 'https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/token'
+        $payload.iss | Should -Be $clientId
+        $payload.sub | Should -Be $clientId
+        $payload.exp | Should -BeGreaterThan $payload.nbf
+
+        $publicKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPublicKey($script:Certificate)
+        try {
+            $publicKey.VerifyData(
+                [System.Text.Encoding]::UTF8.GetBytes("$($parts[0]).$($parts[1])"),
+                (& $script:ConvertFromTestBase64Url -Value $parts[2]),
+                [System.Security.Cryptography.HashAlgorithmName]::SHA256,
+                [System.Security.Cryptography.RSASignaturePadding]::Pkcs1
+            ) | Should -BeTrue
+        } finally {
+            $publicKey.Dispose()
+        }
+    }
+
+    It 'rejects a malformed certificate thumbprint before accessing the store' {
+        { Get-EntraIDTokenFromCertificate `
+                -TenantId 'contoso.onmicrosoft.com' `
+                -ClientId '11111111-2222-3333-4444-555555555555' `
+                -CertificateThumbprint 'not-a-thumbprint' } |
+            Should -Throw '*not valid hexadecimal*'
+
+        Should -Invoke -ModuleName TokenTactics Get-Item -Times 0
+    }
+
+    It 'reports a missing certificate' {
+        Mock -ModuleName TokenTactics Get-Item { throw 'item not found' }
+
+        { Get-EntraIDTokenFromCertificate `
+                -TenantId 'contoso.onmicrosoft.com' `
+                -ClientId '11111111-2222-3333-4444-555555555555' `
+                -CertificateThumbprint $script:Certificate.Thumbprint } |
+            Should -Throw '*was not found*'
+    }
+
+    It 'propagates token endpoint failures' {
+        Mock -ModuleName TokenTactics Invoke-RestMethod { throw 'network error' }
+
+        { Get-EntraIDTokenFromCertificate `
+                -TenantId 'contoso.onmicrosoft.com' `
+                -ClientId '11111111-2222-3333-4444-555555555555' `
+                -CertificateThumbprint $script:Certificate.Thumbprint } |
+            Should -Throw '*network error*'
+    }
+
+    It 'rejects non-Windows certificate stores' {
+        $env:OS = 'Unix'
+        try {
+            { Get-EntraIDTokenFromCertificate `
+                    -TenantId 'contoso.onmicrosoft.com' `
+                    -ClientId '11111111-2222-3333-4444-555555555555' `
+                    -CertificateThumbprint $script:Certificate.Thumbprint } |
+                Should -Throw '*requires a Windows certificate store*'
+        } finally {
+            $env:OS = 'Windows_NT'
+        }
+    }
+}

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
         'ConvertFrom-JWTtoken'
         'ConvertTo-PEMPrivateKey'
         'Get-EntraIDAuthorizationCode'
+        'Get-EntraIDTokenFromCertificate'
         'Get-EntraIDTokenFromDeviceCode'
         'Get-EntraIDTokenFromAuthorizationCode'
         'Get-EntraIDTokenFromCookie'
@@ -35,6 +36,7 @@ BeforeAll {
         'Invoke-RefreshToSharePointToken'
         'Invoke-RefreshToSubstrateToken'
         'Invoke-RefreshToYammerToken'
+        'New-TPMCertificate'
     )
 
     $script:ExpectedAliases = @{

--- a/tests/New-TPMCertificate.Tests.ps1
+++ b/tests/New-TPMCertificate.Tests.ps1
@@ -2,19 +2,13 @@ BeforeAll {
     . "$PSScriptRoot/fixtures/TestData.ps1"
     Import-Module $script:ModulePath -Force
 
-    $script:OriginalOS = $env:OS
-    $env:OS = 'Windows_NT'
     $script:FakeCertificate = [PSCustomObject]@{
         Thumbprint = '0123456789ABCDEF0123456789ABCDEF01234567'
         Subject    = 'CN=EntraID-TPM-Auth'
     }
 }
 
-AfterAll {
-    $env:OS = $script:OriginalOS
-}
-
-Describe 'New-TPMCertificate' {
+Describe 'New-TPMCertificate on Windows' -Skip:(-not $IsWindows) {
     BeforeEach {
         $script:NewCertificateParameters = $null
         $script:ExportParameters = $null
@@ -85,13 +79,11 @@ Describe 'New-TPMCertificate' {
             Should -Throw '*New-SelfSignedCertificate cmdlet is unavailable*'
     }
 
+}
+
+Describe 'New-TPMCertificate on non-Windows systems' -Skip:$IsWindows {
     It 'rejects non-Windows systems' {
-        $env:OS = 'Unix'
-        try {
-            { New-TPMCertificate -Subject 'CN=EntraID-TPM-Auth' } |
-                Should -Throw '*supported only on Windows*'
-        } finally {
-            $env:OS = 'Windows_NT'
-        }
+        { New-TPMCertificate -Subject 'CN=EntraID-TPM-Auth' } |
+            Should -Throw '*supported only on Windows*'
     }
 }

--- a/tests/New-TPMCertificate.Tests.ps1
+++ b/tests/New-TPMCertificate.Tests.ps1
@@ -1,0 +1,97 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+
+    $script:OriginalOS = $env:OS
+    $env:OS = 'Windows_NT'
+    $script:FakeCertificate = [PSCustomObject]@{
+        Thumbprint = '0123456789ABCDEF0123456789ABCDEF01234567'
+        Subject    = 'CN=EntraID-TPM-Auth'
+    }
+}
+
+AfterAll {
+    $env:OS = $script:OriginalOS
+}
+
+Describe 'New-TPMCertificate' {
+    BeforeEach {
+        $script:NewCertificateParameters = $null
+        $script:ExportParameters = $null
+        Mock -ModuleName TokenTactics Get-Command {
+            [PSCustomObject]@{ Name = 'New-SelfSignedCertificate' }
+        } -ParameterFilter { $Name -eq 'New-SelfSignedCertificate' }
+        Mock -ModuleName TokenTactics New-SelfSignedCertificate {
+            param(
+                $Subject,
+                $CertStoreLocation,
+                $Provider,
+                $KeyAlgorithm,
+                $KeyLength,
+                $KeyUsage,
+                $KeyExportPolicy,
+                $NotAfter
+            )
+            $script:NewCertificateParameters = @{
+                Subject           = $Subject
+                CertStoreLocation = $CertStoreLocation
+                Provider          = $Provider
+                KeyAlgorithm      = $KeyAlgorithm
+                KeyLength         = $KeyLength
+                KeyUsage          = $KeyUsage
+                KeyExportPolicy   = $KeyExportPolicy
+                NotAfter          = $NotAfter
+            }
+            $script:FakeCertificate
+        }
+        Mock -ModuleName TokenTactics Export-TTPublicCertificate {
+            param($Certificate, $Path)
+            $script:ExportParameters = @{
+                Certificate = $Certificate
+                Path        = $Path
+            }
+        }
+    }
+
+    It 'creates a non-exportable RSA certificate with the TPM provider' {
+        $result = New-TPMCertificate -Subject 'CN=EntraID-TPM-Auth'
+
+        $result | Should -Be $script:FakeCertificate
+        $script:NewCertificateParameters['Subject'] | Should -Be 'CN=EntraID-TPM-Auth'
+        $script:NewCertificateParameters['CertStoreLocation'] | Should -Be 'Cert:\CurrentUser\My'
+        $script:NewCertificateParameters['Provider'] | Should -Be 'Microsoft Platform Crypto Provider'
+        $script:NewCertificateParameters['KeyAlgorithm'] | Should -Be 'RSA'
+        $script:NewCertificateParameters['KeyLength'] | Should -Be 2048
+        $script:NewCertificateParameters['KeyUsage'] | Should -Be 'DigitalSignature'
+        $script:NewCertificateParameters['KeyExportPolicy'] | Should -Be 'NonExportable'
+    }
+
+    It 'exports only the public certificate when PublicKeyPath is supplied' {
+        New-TPMCertificate -Subject 'CN=EntraID-TPM-Auth' -PublicKeyPath 'C:\Temp\EntraID-TPM-Auth.cer' | Should -Be $script:FakeCertificate
+
+        $script:ExportParameters['Certificate'] | Should -Be $script:FakeCertificate
+        $script:ExportParameters['Path'] | Should -Be 'C:\Temp\EntraID-TPM-Auth.cer'
+    }
+
+    It 'rejects a non-CER public key path' {
+        { New-TPMCertificate -Subject 'CN=EntraID-TPM-Auth' -PublicKeyPath 'C:\Temp\certificate.pem' } |
+            Should -Throw
+    }
+
+    It 'reports an unavailable PKI cmdlet before creation' {
+        Mock -ModuleName TokenTactics Get-Command { $null } -ParameterFilter { $Name -eq 'New-SelfSignedCertificate' }
+
+        { New-TPMCertificate -Subject 'CN=EntraID-TPM-Auth' } |
+            Should -Throw '*New-SelfSignedCertificate cmdlet is unavailable*'
+    }
+
+    It 'rejects non-Windows systems' {
+        $env:OS = 'Unix'
+        try {
+            { New-TPMCertificate -Subject 'CN=EntraID-TPM-Auth' } |
+                Should -Throw '*supported only on Windows*'
+        } finally {
+            $env:OS = 'Windows_NT'
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TPM-backed certificate creation with optional public DER export
- add Entra ID client-credentials authentication using certificate assertions
- document setup and add portable Pester coverage

## Validation
- pwsh -NoProfile -File .\tests\Invoke-Tests.ps1