### PR TITLE
feat: split passkey login into modular cmdlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,33 @@ Invoke-EntraIDPasskeyLogin -Verbose -UserPrincipalName "myUserName@example.com" 
 Get-EntraIDTokenFromESTSCookie -CookieValue $Global:ESTSAUTH
 ```
 
+#### Split passkey flow (e.g. Windows Hello for Business)
+
+The passkey sign-in is also available as separate cmdlets, which allows the assertion to be signed on a different machine than the one running the login flow — for example with a Windows Hello for Business credential (based on [ROADtools](https://github.com/dirkjanm/ROADtools) by Dirk-jan Mollema, MIT licensed).
+
+```powershell
+# 1. Retrieve a FIDO2 challenge (saves the web session as $global:Fido2WebSession)
+$challenge = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com"
+
+# 2. Create a signed assertion with the Windows Hello for Business key (Windows only)
+#    The object ID is derived from the certificate's user SID; pass -UserId to override it.
+#    The assertion is returned as a JSON string, e.g. for transfer via clipboard:
+#    Get-WindowsHelloFidoAssertion -Challenge $challenge | Set-Clipboard
+$assertion = Get-WindowsHelloFidoAssertion -Challenge $challenge -UserId "00000000-0000-0000-0000-000000000002"
+
+# 3. Complete the sign-in. Returns an access token and refresh token by default.
+Invoke-EntraIDPasskeyAssertionLogin -Assertion $assertion
+
+# Alternatively, return the ESTSAUTH cookie value instead of tokens
+Invoke-EntraIDPasskeyAssertionLogin -Assertion $assertion -OutputType ESTSAUTHCookie
+```
+
+If you need the FIDO2 user handle of a user (e.g. for the software-based passkey flow), you can calculate it from the tenant ID and the user's object ID:
+
+```powershell
+New-EntraIDUserHandle -TenantId "00000000-0000-0000-0000-000000000001" -UserId "00000000-0000-0000-0000-000000000002"
+```
+
 ### Get access tokens using the SCCAUTH cookie
 
 If you have obtained an `sccauth` cookie from an authenticated session to `security.microsoft.com` (e.g., via Evilginx or browser DevTools), you can use it to retrieve Entra ID access tokens for a broad set of resources through the Microsoft Defender XDR portal.
@@ -240,6 +267,13 @@ Only supported user-facing commands are exported; parsing, PKCE, generic refresh
 TokenTactic's methods are highly influenced by the great research of Dr Nestori Syynimaa at https://o365blog.com/.
 
 ## Changelog
+
+### 0.4.0 (2026-08-12)
+
+* Add `Get-EntraIDFido2Challenge` to retrieve a FIDO2 sign-in challenge and save the web session for the split passkey flow.
+* Add `Get-WindowsHelloFidoAssertion` to create a signed WebAuthn assertion with a Windows Hello for Business key. Based on `fido_assertion.ps1` by Dirk-jan Mollema ([ROADtools](https://github.com/dirkjanm/ROADtools)), released under the MIT license.
+* Add `New-EntraIDUserHandle` to calculate the FIDO2 user handle from a tenant ID and user object ID.
+* Add `Invoke-EntraIDPasskeyAssertionLogin` to complete the passkey sign-in from a signed assertion, returning tokens by default or the ESTSAUTH cookie via `-OutputType ESTSAUTHCookie`.
 
 ### 0.3.3 (2026-08-05)
 

--- a/README.md
+++ b/README.md
@@ -107,27 +107,40 @@ Get-EntraIDTokenFromESTSCookie -CookieValue $Global:ESTSAUTH
 The passkey sign-in is also available as separate cmdlets, which allows the assertion to be signed on a different machine than the one running the login flow — for example with a Windows Hello for Business credential (based on [ROADtools](https://github.com/dirkjanm/ROADtools) by Dirk-jan Mollema, MIT licensed).
 
 ```powershell
-# 1. Retrieve a FIDO2 challenge (saves the web session as $global:Fido2WebSession)
-$challenge = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com"
+# 1. Retrieve structured FIDO2 flow state (also saves $global:Fido2FlowState and
+#    the web session as $global:Fido2WebSession)
+$flow = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com" -Client MSGraph
 
 # 2. Create a signed assertion with the Windows Hello for Business key (Windows only)
 #    The object ID is derived from the certificate's user SID; pass -UserId to override it.
 #    The assertion is returned as a JSON string, e.g. for transfer via clipboard:
-#    Get-WindowsHelloFidoAssertion -Challenge $challenge | Set-Clipboard
-$assertion = Get-WindowsHelloFidoAssertion -Challenge $challenge -UserId "00000000-0000-0000-0000-000000000002"
+#    Get-WindowsHelloFidoAssertion -Challenge $flow.Challenge | Set-Clipboard
+$assertion = Get-WindowsHelloFidoAssertion -Challenge $flow.Challenge -UserId "00000000-0000-0000-0000-000000000002"
 
 # 3. Complete the sign-in. Returns an access token and refresh token by default.
-Invoke-EntraIDPasskeyAssertionLogin -Assertion $assertion
+Invoke-EntraIDPasskeyAssertionLogin -FlowState $flow -Assertion $assertion
 
 # Alternatively, return the ESTSAUTH cookie value instead of tokens
 Invoke-EntraIDPasskeyAssertionLogin -Assertion $assertion -OutputType ESTSAUTHCookie
 ```
+
+The challenge cmdlet builds the authorization URL from the same client names used by the
+refresh-token cmdlets, such as `MSGraph`, `Graph`, `MSTeams`, `AzureManagement`, `SharePoint`,
+and `DeviceRegistration`. OAuth options include `-Tenant`, `-Authority`, `-RedirectUrl`,
+`-Scope`, `-Resource`, `-UseV1Endpoint`, `-UseCAE`, `-UseCodeVerifier`, and `-CodeVerifier`.
+When `-RedirectUrl` is omitted, the helper selects the preferred registered redirect URI for the
+effective client ID using its maintained first-party client mapping; an explicit value overrides it.
+Use `-AuthUrl` when a complete custom authorization URL is required. Unknown/custom client IDs
+must provide `-RedirectUrl` because a generic native redirect may not be registered for that app.
 
 If you need the FIDO2 user handle of a user (e.g. for the software-based passkey flow), you can calculate it from the tenant ID and the user's object ID:
 
 ```powershell
 New-EntraIDUserHandle -TenantId "00000000-0000-0000-0000-000000000001" -UserId "00000000-0000-0000-0000-000000000002"
 ```
+
+Use the returned `UserHandle` or `UserHandleBase64Url` property in an assertion. The legacy
+`UserHandleBase64` property remains padded standard Base64 for compatibility.
 
 ### Get access tokens using the SCCAUTH cookie
 

--- a/TokenTactics.psd1
+++ b/TokenTactics.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'TokenTactics.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.3.3'
+    ModuleVersion     = '0.4.0'
     
     # ID used to uniquely identify this module
     GUID              = '6194f0f0-8b91-4c32-b1b1-bc46c9d7a95c'
@@ -23,6 +23,7 @@
         'ConvertFrom-JWTtoken'
         'ConvertTo-PEMPrivateKey'
         'Get-EntraIDAuthorizationCode'
+        'Get-EntraIDFido2Challenge'
         'Get-EntraIDTokenFromCertificate'
         'Get-EntraIDTokenFromDeviceCode'
         'Get-EntraIDTokenFromAuthorizationCode'
@@ -33,6 +34,8 @@
         'Get-EntraIDTokenFromSCCAUTHCookie'
         'Get-ForgedUserAgent'
         'Get-TenantID'
+        'Get-WindowsHelloFidoAssertion'
+        'Invoke-EntraIDPasskeyAssertionLogin'
         'Invoke-EntraIDPasskeyLogin'
         'Invoke-RefreshToAzureCoreManagementToken'
         'Invoke-RefreshToAzureKeyVaultToken'
@@ -52,6 +55,7 @@
         'Invoke-RefreshToSharePointToken'
         'Invoke-RefreshToSubstrateToken'
         'Invoke-RefreshToYammerToken'
+        'New-EntraIDUserHandle'
         'New-TPMCertificate'
     )
 

--- a/TokenTactics.psm1
+++ b/TokenTactics.psm1
@@ -42,6 +42,7 @@ $functions = @(
     "ConvertFrom-JWTtoken"
     "ConvertTo-PEMPrivateKey"
     "Get-EntraIDAuthorizationCode"
+    "Get-EntraIDFido2Challenge"
     "Get-EntraIDTokenFromCertificate"
     "Get-EntraIDTokenFromDeviceCode"
     "Get-EntraIDTokenFromAuthorizationCode"
@@ -52,6 +53,8 @@ $functions = @(
     "Get-EntraIDTokenFromSCCAUTHCookie"
     "Get-ForgedUserAgent"
     "Get-TenantID"
+    "Get-WindowsHelloFidoAssertion"
+    "Invoke-EntraIDPasskeyAssertionLogin"
     "Invoke-EntraIDPasskeyLogin"
     "Invoke-RefreshToAzureCoreManagementToken"
     "Invoke-RefreshToAzureKeyVaultToken"
@@ -71,6 +74,7 @@ $functions = @(
     "Invoke-RefreshToSharePointToken"
     "Invoke-RefreshToSubstrateToken"
     "Invoke-RefreshToYammerToken"
+    "New-EntraIDUserHandle"
     "New-TPMCertificate"
 )
 

--- a/modules/Get-EntraIDFido2Challenge.ps1
+++ b/modules/Get-EntraIDFido2Challenge.ps1
@@ -7,10 +7,10 @@
     has FIDO2 credentials registered and returns the server-issued FIDO2 challenge string
     (sFidoChallenge).
 
-    The web session is saved as $global:Fido2WebSession (with the parsed session information
-    attached as property Fido2SessionInfo) so that Invoke-EntraIDPasskeyAssertionLogin can
-    complete the sign-in in the same PowerShell session. The challenge itself is
-    session-bound and cannot be replayed against a different session.
+    A structured flow state is returned and saved as $global:Fido2FlowState. The web session is
+    also saved as $global:Fido2WebSession with the legacy Fido2SessionInfo property attached, so
+    Invoke-EntraIDPasskeyAssertionLogin can complete the sign-in in the same PowerShell session.
+    The challenge itself is session-bound and cannot be replayed against a different session.
 
     The challenge string can be transferred to another machine (e.g. a Windows client with a
     Windows Hello for Business key) to create a signed assertion with
@@ -23,9 +23,50 @@
     The relying party identifier (RP ID). Defaults to "login.microsoft.com".
 
 .PARAMETER AuthUrl
-    The OAuth2 authorize URL used to start the flow. Must contain client_id, response_type
-    and redirect_uri. Defaults to the Azure AD v2.0 authorize endpoint for the Microsoft
-    Azure CLI client.
+    Optional complete OAuth2 authorize URL. When omitted, the URL is built from Client and the
+    OAuth parameters below.
+
+.PARAMETER Client
+    Built-in OAuth client name. Names mirror Invoke-RefreshToToken.ps1, including MSGraph,
+    Graph, MSTeams, AzureManagement, SharePoint and DeviceRegistration.
+
+.PARAMETER ClientID
+    Overrides the client ID associated with Client. Required with Client Custom.
+
+.PARAMETER Tenant
+    Entra tenant segment used in the authorize URL. Defaults to organizations.
+
+.PARAMETER Authority
+    Login authority host. Defaults to login.microsoftonline.com.
+
+.PARAMETER RedirectUrl
+    OAuth redirect URI. When omitted, the helper selects the preferred registered redirect URI
+    for the effective client ID. An explicit value overrides the client mapping.
+
+.PARAMETER Scope
+    Custom OAuth scope. Built-in clients get their scope from Client.
+
+.PARAMETER Resource
+    OAuth v1 resource value. Used with -UseV1Endpoint.
+
+.PARAMETER UseV1Endpoint
+    Uses the v1 authorize endpoint and resource parameter.
+
+.PARAMETER UseCAE
+    Adds the cp1 claims request to a v2 authorize URL.
+
+.PARAMETER UseCodeVerifier
+    Adds a PKCE S256 challenge to the authorize URL and stores the verifier in the flow state.
+
+.PARAMETER CodeVerifier
+    Optional PKCE verifier. If omitted with -UseCodeVerifier, one is generated.
+
+.PARAMETER AuthorizationCodeState
+    OAuth state value. A GUID is generated when omitted.
+
+.PARAMETER OutputType
+    FlowState (default) returns the structured flow state. Challenge returns only the challenge
+    string for compatibility with older scripts.
 
 .PARAMETER UserAgent
     The user agent string used for the web session.
@@ -34,17 +75,87 @@
     Optional proxy URL used for all web requests.
 
 .EXAMPLE
-    $challenge = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com"
-    Retrieves a FIDO2 challenge and saves the web session for Invoke-EntraIDPasskeyAssertionLogin.
+    $flow = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com" -Client MSGraph
+    Retrieves structured FIDO2 flow state and saves the web session.
 
 .EXAMPLE
-    Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com" | Set-Clipboard
+    (Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com").Challenge | Set-Clipboard
     Retrieves a FIDO2 challenge and copies it to the clipboard for use on another machine.
 
 .NOTES
     Part of TokenTacticsV2
     https://github.com/f-bader/TokenTacticsV2
 #>
+function Get-TTJsonObjectCandidates {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content
+    )
+
+    # Locate balanced JSON objects instead of using a greedy regex. The
+    # authorize response is commonly emitted as `$Config = {...};` and may be
+    # wrapped in a script block or HTML.
+    for ($start = 0; $start -lt $Content.Length; $start++) {
+        if ($Content[$start] -ne '{') { continue }
+
+        $depth = 0
+        $inString = $false
+        $escaped = $false
+        for ($index = $start; $index -lt $Content.Length; $index++) {
+            $character = $Content[$index]
+            if ($inString) {
+                if ($escaped) {
+                    $escaped = $false
+                } elseif ($character -eq '\') {
+                    $escaped = $true
+                } elseif ($character -eq '"') {
+                    $inString = $false
+                }
+                continue
+            }
+
+            if ($character -eq '"') {
+                $inString = $true
+            } elseif ($character -eq '{') {
+                $depth++
+            } elseif ($character -eq '}') {
+                $depth--
+                if ($depth -eq 0) {
+                    $Content.Substring($start, $index - $start + 1)
+                    break
+                }
+            }
+        }
+    }
+}
+
+function ConvertFrom-TTEntraFidoResponse {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Content
+    )
+
+    $fallback = $null
+    $candidates = @($Content.Trim()) + @(Get-TTJsonObjectCandidates -Content $Content)
+    foreach ($candidate in $candidates) {
+        try {
+            $parsed = $candidate.Trim().TrimEnd(';').Trim() | ConvertFrom-Json -Depth 100 -ErrorAction Stop
+        } catch {
+            continue
+        }
+
+        if ($parsed.sFidoChallenge -or $parsed.oGetCredTypeResult -or $parsed.urlPost) {
+            return $parsed
+        }
+        if (-not $fallback) { $fallback = $parsed }
+    }
+
+    if ($fallback) { return $fallback }
+    throw 'The authorize response did not contain a valid Entra FIDO configuration object.'
+}
+
 function Get-EntraIDFido2Challenge {
     [CmdletBinding()]
     param (
@@ -53,10 +164,43 @@ function Get-EntraIDFido2Challenge {
         [string]$UserPrincipalName,
 
         [Parameter(Mandatory = $false)]
-        $RelyingParty = "login.microsoft.com",
+        [string]$RelyingParty = "login.microsoft.com",
 
         [Parameter(Mandatory = $false)]
-        $AuthUrl = "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?response_type=code&redirect_uri=msauth.com.msauth.unsignedapp://auth&scope=https://graph.microsoft.com/.default&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46",
+        [string]$AuthUrl,
+
+        [ValidateSet('Substrate','MSManage','MSTeams','OfficeManagement','Outlook','MSGraph','Graph','OfficeApps','AzureCoreManagement','AzureStorage','AzureKeyVault','AzureManagement','MAM','DODMSGraph','SharePoint','OneDrive','Yammer','DeviceRegistration','Custom')]
+        [string]$Client = 'MSGraph',
+
+        [string]$ClientID,
+
+        [string]$Tenant = 'organizations',
+
+        [string]$Authority = 'login.microsoftonline.com',
+
+        [string]$RedirectUrl,
+
+        [string]$Scope,
+
+        [string]$Resource,
+
+        [string]$SharePointTenantName,
+
+        [switch]$SharePointUseAdmin,
+
+        [switch]$UseV1Endpoint,
+
+        [switch]$UseCAE,
+
+        [switch]$UseCodeVerifier,
+
+        [string]$CodeVerifier,
+
+        [Alias('State')]
+        [string]$AuthorizationCodeState,
+
+        [ValidateSet('FlowState', 'Challenge')]
+        [string]$OutputType = 'FlowState',
 
         [Parameter(Mandatory = $false)]
         $UserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0',
@@ -81,48 +225,33 @@ function Get-EntraIDFido2Challenge {
     $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
     $session.UserAgent = $UserAgent
 
-    # Add mandatory fields to URI
-    # Get all existing query parameters
-    try {
-        $uriBuilder = [System.UriBuilder]$AuthUrl
-        $query = [System.Web.HttpUtility]::ParseQueryString($uriBuilder.Query)
-    } catch {
-        throw "Invalid auth URL format. $($_.Exception.Message)"
-    }
-    if ( $AuthUrl -notmatch "^https://login.microsoftonline.com/" ) {
-        throw "Auth URL must start with 'https://login.microsoftonline.com/'"
-    }
-    # Check if required parameters are already present
-    # scope
-    # client_id
-    # response_type
-    # redirect_uri
-    $RequiredParams = @("client_id", "response_type", "redirect_uri")
-    foreach ($param in $RequiredParams) {
-        if (-not $query.Get($param)) {
-            throw "Missing required parameter '$param' in auth URL."
-        }
-    }
-    # Add additional required parameters if missing
-    # sso_reload=true
-    # login_hint=$UserPrincipalName
-    if (-not $query.Get("sso_reload")) {
-        $AuthUrl = "$AuthUrl&sso_reload=true"
-    }
-    if (-not $query.Get("login_hint")) {
-        $AuthUrl = "$AuthUrl&login_hint=$UserPrincipalName"
-    }
+    $oauth = New-TTEntraAuthorizationUrl `
+        -Client $Client `
+        -ClientID $ClientID `
+        -Tenant $Tenant `
+        -Authority $Authority `
+        -RedirectUrl $RedirectUrl `
+        -Scope $Scope `
+        -Resource $Resource `
+        -SharePointTenantName $SharePointTenantName `
+        -SharePointUseAdmin:$SharePointUseAdmin `
+        -UseV1Endpoint:$UseV1Endpoint `
+        -UseCAE:$UseCAE `
+        -UseCodeVerifier:$UseCodeVerifier `
+        -CodeVerifier $CodeVerifier `
+        -AuthorizationCodeState $AuthorizationCodeState `
+        -Username $UserPrincipalName `
+        -AuthUrl $AuthUrl
+    $AuthUrl = $oauth.Url
     Write-Verbose "$([char]0x2718) Auth URL: $AuthUrl"
 
     # This sets the initial ESTS cookies and flow state.
     Write-Host "$([char]0x2718) Warming up session on login.microsoftonline.com (Authorize)..." -ForegroundColor Cyan
     try {
-        $InitialResponse = Invoke-WebRequest -UseBasicParsing -Uri $AuthUrl -Method Get -WebSession $session
-        $InitialResponse.Content -match '{(.*)}' | Out-Null
-        $SessionInformation = $Matches[0] | ConvertFrom-Json
+        $InitialResponse = Invoke-WebRequest -UseBasicParsing -Uri $AuthUrl -Method Get -WebSession $session -ErrorAction Stop
+        $SessionInformation = ConvertFrom-TTEntraFidoResponse -Content ([string]$InitialResponse.Content)
     } catch {
-        # It's expected to redirect or fail if we don't follow the full HTML flow,
-        # but we just need the Cookies in $session.
+        throw "Could not retrieve or parse the Entra FIDO challenge response. $($_.Exception.Message)"
     }
 
     # Validate Credential Type
@@ -140,14 +269,29 @@ function Get-EntraIDFido2Challenge {
     Write-Host "$([char]0x2714) RP ID:  $rpId" -ForegroundColor Gray
     Write-Host "$([char]0x2714) Origin: $origin" -ForegroundColor Gray
 
+    $flowState = [PSCustomObject]@{
+        PSTypeName         = 'TokenTactics.EntraIDFido2FlowState'
+        Challenge          = [string]$SessionInformation.sFidoChallenge
+        UserPrincipalName  = $UserPrincipalName
+        RelyingParty       = $rpId
+        Origin             = $origin
+        OAuth              = $oauth
+        SessionInformation = $SessionInformation
+        PostbackUrl        = [string]$SessionInformation.urlPost
+        CreatedAt          = [DateTimeOffset]::UtcNow
+        WebSession         = $session
+    }
+
     # Enrich session information with the flow context needed by Invoke-EntraIDPasskeyAssertionLogin
     Add-Member -InputObject $SessionInformation -NotePropertyName 'UserPrincipalName' -NotePropertyValue $UserPrincipalName -Force
-
     # Save session state for Invoke-EntraIDPasskeyAssertionLogin (session info travels with the session)
     Add-Member -InputObject $session -NotePropertyName 'Fido2SessionInfo' -NotePropertyValue $SessionInformation -Force
     $global:Fido2WebSession = $session
-    Write-Host "$([char]0x26BF) Web session saved as `$global:Fido2WebSession for use with Invoke-EntraIDPasskeyAssertionLogin." -ForegroundColor Gray
+    $global:Fido2FlowState = $flowState
+    Write-Host "$([char]0x26BF) Flow state saved as `$global:Fido2FlowState and web session as `$global:Fido2WebSession." -ForegroundColor Gray
 
-    # Output only the challenge (portable to another machine for assertion signing)
-    return $SessionInformation.sFidoChallenge
+    if ($OutputType -eq 'Challenge') {
+        return $flowState.Challenge
+    }
+    return $flowState
 }

--- a/modules/Get-EntraIDFido2Challenge.ps1
+++ b/modules/Get-EntraIDFido2Challenge.ps1
@@ -1,0 +1,153 @@
+<#
+.SYNOPSIS
+    Retrieves a FIDO2 sign-in challenge from Entra ID for a given user.
+
+.DESCRIPTION
+    Starts an Entra ID authorization flow for the specified user, validates that the user
+    has FIDO2 credentials registered and returns the server-issued FIDO2 challenge string
+    (sFidoChallenge).
+
+    The web session is saved as $global:Fido2WebSession (with the parsed session information
+    attached as property Fido2SessionInfo) so that Invoke-EntraIDPasskeyAssertionLogin can
+    complete the sign-in in the same PowerShell session. The challenge itself is
+    session-bound and cannot be replayed against a different session.
+
+    The challenge string can be transferred to another machine (e.g. a Windows client with a
+    Windows Hello for Business key) to create a signed assertion with
+    Get-WindowsHelloFidoAssertion.
+
+.PARAMETER UserPrincipalName
+    The user principal name of the target user.
+
+.PARAMETER RelyingParty
+    The relying party identifier (RP ID). Defaults to "login.microsoft.com".
+
+.PARAMETER AuthUrl
+    The OAuth2 authorize URL used to start the flow. Must contain client_id, response_type
+    and redirect_uri. Defaults to the Azure AD v2.0 authorize endpoint for the Microsoft
+    Azure CLI client.
+
+.PARAMETER UserAgent
+    The user agent string used for the web session.
+
+.PARAMETER Proxy
+    Optional proxy URL used for all web requests.
+
+.EXAMPLE
+    $challenge = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com"
+    Retrieves a FIDO2 challenge and saves the web session for Invoke-EntraIDPasskeyAssertionLogin.
+
+.EXAMPLE
+    Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com" | Set-Clipboard
+    Retrieves a FIDO2 challenge and copies it to the clipboard for use on another machine.
+
+.NOTES
+    Part of TokenTacticsV2
+    https://github.com/f-bader/TokenTacticsV2
+#>
+function Get-EntraIDFido2Challenge {
+    [CmdletBinding()]
+    param (
+        [Alias('UserName')]
+        [Parameter(Mandatory)]
+        [string]$UserPrincipalName,
+
+        [Parameter(Mandatory = $false)]
+        $RelyingParty = "login.microsoft.com",
+
+        [Parameter(Mandatory = $false)]
+        $AuthUrl = "https://login.microsoftonline.com/organizations/oauth2/v2.0/authorize?response_type=code&redirect_uri=msauth.com.msauth.unsignedapp://auth&scope=https://graph.microsoft.com/.default&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46",
+
+        [Parameter(Mandatory = $false)]
+        $UserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36 Edg/142.0.0.0',
+
+        [Parameter(Mandatory = $false)]
+        [string]$Proxy
+    )
+
+    # Configure Default Parameters
+    $PSDefaultParameterValues = @{}
+    $PSDefaultParameterValues.Add('Invoke-WebRequest:Verbose', $false)
+
+    if ($Proxy) {
+        Write-Verbose "$([char]0x2718) Setting proxy to $Proxy"
+        $PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy', $Proxy)
+    }
+
+    $rpId = $RelyingParty
+    $origin = "https://$($rpId)"
+
+    # Configure Session
+    $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+    $session.UserAgent = $UserAgent
+
+    # Add mandatory fields to URI
+    # Get all existing query parameters
+    try {
+        $uriBuilder = [System.UriBuilder]$AuthUrl
+        $query = [System.Web.HttpUtility]::ParseQueryString($uriBuilder.Query)
+    } catch {
+        throw "Invalid auth URL format. $($_.Exception.Message)"
+    }
+    if ( $AuthUrl -notmatch "^https://login.microsoftonline.com/" ) {
+        throw "Auth URL must start with 'https://login.microsoftonline.com/'"
+    }
+    # Check if required parameters are already present
+    # scope
+    # client_id
+    # response_type
+    # redirect_uri
+    $RequiredParams = @("client_id", "response_type", "redirect_uri")
+    foreach ($param in $RequiredParams) {
+        if (-not $query.Get($param)) {
+            throw "Missing required parameter '$param' in auth URL."
+        }
+    }
+    # Add additional required parameters if missing
+    # sso_reload=true
+    # login_hint=$UserPrincipalName
+    if (-not $query.Get("sso_reload")) {
+        $AuthUrl = "$AuthUrl&sso_reload=true"
+    }
+    if (-not $query.Get("login_hint")) {
+        $AuthUrl = "$AuthUrl&login_hint=$UserPrincipalName"
+    }
+    Write-Verbose "$([char]0x2718) Auth URL: $AuthUrl"
+
+    # This sets the initial ESTS cookies and flow state.
+    Write-Host "$([char]0x2718) Warming up session on login.microsoftonline.com (Authorize)..." -ForegroundColor Cyan
+    try {
+        $InitialResponse = Invoke-WebRequest -UseBasicParsing -Uri $AuthUrl -Method Get -WebSession $session
+        $InitialResponse.Content -match '{(.*)}' | Out-Null
+        $SessionInformation = $Matches[0] | ConvertFrom-Json
+    } catch {
+        # It's expected to redirect or fail if we don't follow the full HTML flow,
+        # but we just need the Cookies in $session.
+    }
+
+    # Validate Credential Type
+    Write-Host "$([char]0x2718) Validate FIDO2 Credential Type..." -ForegroundColor Cyan
+    if (-not $SessionInformation.oGetCredTypeResult.Credentials.HasFido) {
+        throw "User does not have FIDO credentials registered."
+    }
+
+    if (-not $SessionInformation.sFidoChallenge) {
+        throw "No FIDO challenge received from server."
+    }
+
+    Write-Host "$([char]0x2714) Challenge Received." -ForegroundColor Green
+    Write-Host "$([char]0x2714) User:   $UserPrincipalName" -ForegroundColor Gray
+    Write-Host "$([char]0x2714) RP ID:  $rpId" -ForegroundColor Gray
+    Write-Host "$([char]0x2714) Origin: $origin" -ForegroundColor Gray
+
+    # Enrich session information with the flow context needed by Invoke-EntraIDPasskeyAssertionLogin
+    Add-Member -InputObject $SessionInformation -NotePropertyName 'UserPrincipalName' -NotePropertyValue $UserPrincipalName -Force
+
+    # Save session state for Invoke-EntraIDPasskeyAssertionLogin (session info travels with the session)
+    Add-Member -InputObject $session -NotePropertyName 'Fido2SessionInfo' -NotePropertyValue $SessionInformation -Force
+    $global:Fido2WebSession = $session
+    Write-Host "$([char]0x26BF) Web session saved as `$global:Fido2WebSession for use with Invoke-EntraIDPasskeyAssertionLogin." -ForegroundColor Gray
+
+    # Output only the challenge (portable to another machine for assertion signing)
+    return $SessionInformation.sFidoChallenge
+}

--- a/modules/Get-EntraIDTokenFromCookie.ps1
+++ b/modules/Get-EntraIDTokenFromCookie.ps1
@@ -42,6 +42,8 @@ function Get-EntraIDTokenFromCookie {
         [Parameter(Mandatory = $false)]
         [switch]$UseCodeVerifier,
         [Parameter(Mandatory = $false)]
+        [string]$CodeVerifier,
+        [Parameter(Mandatory = $false)]
         [switch]$UseV1Endpoint,
         [Parameter(Mandatory = $false)]
         [switch]$UseCAE,
@@ -103,7 +105,9 @@ function Get-EntraIDTokenFromCookie {
         $Uri = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?response_type=code&client_id=$($ClientID)&scope=$($Scope)&redirect_uri=$($redirect_uri)&state=$($state)"
     }
     if ($UseCodeVerifier) {
-        $CodeVerifier = Get-TTCodeVerifier
+        if ([string]::IsNullOrWhiteSpace($CodeVerifier)) {
+            $CodeVerifier = Get-TTCodeVerifier
+        }
         $CodeChallenge = Get-TTCodeChallenge -CodeVerifier $CodeVerifier
         $Uri += "&code_challenge=$CodeChallenge&code_challenge_method=S256"
     }
@@ -311,6 +315,14 @@ function Get-EntraIDTokenFromESTSCookie {
         [Parameter(Mandatory = $False)]
         [string]$RedirectUrl = "https://login.microsoftonline.com/common/oauth2/nativeclient",
         [Parameter(Mandatory = $false)]
+        [switch]$UseCodeVerifier,
+        [Parameter(Mandatory = $false)]
+        [string]$CodeVerifier,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseV1Endpoint,
+        [Parameter(Mandatory = $false)]
+        [switch]$UseCAE,
+        [Parameter(Mandatory = $false)]
         [string]$Proxy
     )
 
@@ -343,6 +355,10 @@ function Get-EntraIDTokenFromESTSCookie {
         "Scope"       = $Scope
         "RedirectUrl" = $RedirectUrl
         "Verbose"     = $VerbosePreference
+        "UseCodeVerifier" = $UseCodeVerifier
+        "CodeVerifier" = $CodeVerifier
+        "UseV1Endpoint" = $UseV1Endpoint
+        "UseCAE" = $UseCAE
     }
     if ($Proxy) {
         $Parameters.Add("Proxy", $Proxy)

--- a/modules/Get-WindowsHelloFidoAssertion.ps1
+++ b/modules/Get-WindowsHelloFidoAssertion.ps1
@@ -1,0 +1,392 @@
+<#
+.SYNOPSIS
+    Creates a signed WebAuthn (FIDO2) assertion using a Windows Hello for Business key.
+
+.DESCRIPTION
+    Generates a FIDO2 assertion for an Entra ID sign-in challenge using the Windows Hello
+    for Business credential of the current user. The private key never leaves the TPM;
+    signing is performed through the NCrypt API.
+
+    The Windows Hello for Business certificate is located in the current user's certificate
+    store (subject contains "login.windows.net"). The user handle is derived from the
+    certificate subject (tenant ID) and the user's object ID. If no user ID is supplied, the
+    object ID is derived from the user SID in the certificate subject. The credential ID is
+    the Base64Url encoded SHA256 hash of the exported RSA public key blob.
+
+    This command requires Windows and a Windows Hello for Business provisioned user.
+
+    The assertion is returned as a compressed JSON string, so it can easily be transferred
+    to the machine running Invoke-EntraIDPasskeyAssertionLogin (e.g. via clipboard).
+
+.PARAMETER Challenge
+    The server-issued FIDO2 challenge string, e.g. from Get-EntraIDFido2Challenge.
+
+.PARAMETER UserId
+    The Entra ID object ID (GUID) of the user that owns the Windows Hello credential.
+    If omitted, the object ID is derived from the user SID in the certificate subject.
+
+.PARAMETER RpId
+    The relying party identifier. Defaults to "login.microsoft.com".
+
+.PARAMETER Origin
+    The origin of the authentication request. Defaults to "https://login.microsoft.com".
+
+.PARAMETER SignCount
+    The signature counter value. Defaults to 0.
+
+.EXAMPLE
+    $assertion = Get-WindowsHelloFidoAssertion -Challenge $challenge -UserId "00000000-0000-0000-0000-000000000002"
+    Creates a signed assertion that can be passed to Invoke-EntraIDPasskeyAssertionLogin.
+
+.EXAMPLE
+    $assertion = Get-WindowsHelloFidoAssertion -Challenge $challenge
+    Creates a signed assertion, deriving the object ID from the certificate's user SID.
+
+.NOTES
+    Part of TokenTacticsV2
+    https://github.com/f-bader/TokenTacticsV2
+
+    Based on fido_assertion.ps1 by Dirk-jan Mollema (@dirkjanm), part of ROADtools,
+    released under the MIT license.
+    https://github.com/dirkjanm/ROADtools/blob/master/winhello_assertion/fido_assertion.ps1
+#>
+
+function ConvertFrom-TTUserSid {
+    <#
+    .SYNOPSIS
+        Converts an Entra ID user SID (S-1-12-1-...) to the user's object ID.
+        Private helper for Get-WindowsHelloFidoAssertion.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Sid
+    )
+
+    # Entra ID user SIDs encode the object ID as four little-endian UInt32 sub-authorities
+    $parts = $Sid.Split('-')
+    if ($parts.Count -lt 8 -or $parts[0] -ne 'S' -or $parts[1] -ne '1' -or $parts[2] -ne '12') {
+        throw "'$Sid' is not a valid Entra ID user SID (expected format S-1-12-1-...)."
+    }
+
+    $bytes = [byte[]]::new(16)
+    for ($i = 0; $i -lt 4; $i++) {
+        $subAuthority = [uint32]::Parse($parts[4 + $i])
+        $subBytes = [BitConverter]::GetBytes($subAuthority)
+        if (-not [BitConverter]::IsLittleEndian) { [Array]::Reverse($subBytes) }
+        [Array]::Copy($subBytes, 0, $bytes, $i * 4, 4)
+    }
+    return [Guid]::new($bytes)
+}
+
+function Get-WindowsHelloFidoAssertion {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Challenge,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateScript({
+            if ([guid]::TryParse($_, [ref]([guid]::Empty))) { $true }
+            else { throw "UserId must be the Entra ID object ID (GUID) of the user, not a UPN. Omit -UserId to derive it from the certificate." }
+        })]
+        [string]$UserId,
+
+        [Parameter(Mandatory = $false)]
+        [string]$RpId = "login.microsoft.com",
+
+        [Parameter(Mandatory = $false)]
+        [string]$Origin = "https://login.microsoft.com",
+
+        [Parameter(Mandatory = $false)]
+        [int]$SignCount = 0
+    )
+
+    if ($env:OS -ne 'Windows_NT') {
+        throw 'Get-WindowsHelloFidoAssertion is supported only on Windows.'
+    }
+
+    # NCrypt Native API definitions
+    if (-not ([System.Management.Automation.PSTypeName]'NCrypt').Type) {
+        Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+public class NCrypt {
+    [DllImport("Crypt32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    public static extern bool CertGetCertificateContextProperty(
+        IntPtr pCertContext,
+        uint dwPropId,
+        IntPtr pvData,
+        ref uint pcbData
+    );
+
+    [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+    public struct CRYPT_KEY_PROV_INFO {
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string pwszContainerName;
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string pwszProvName;
+        public uint dwProvType;
+        public uint dwFlags;
+        public uint cProvParam;
+        public IntPtr rgProvParam;
+        public uint dwKeySpec;
+    }
+
+    [DllImport("ncrypt.dll", SetLastError = true)]
+    public static extern int NCryptOpenStorageProvider(
+        ref IntPtr phProvider,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string pszProviderName,
+        uint dwFlags
+    );
+
+    [DllImport("ncrypt.dll", SetLastError = true)]
+    public static extern int NCryptOpenKey(
+        IntPtr hProvider,
+        ref IntPtr phKey,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string pszKeyName,
+        uint dwLegacyKeySpec,
+        uint dwFlags
+    );
+
+    [DllImport("ncrypt.dll", SetLastError = true)]
+    public static extern int NCryptSignHash(
+        IntPtr hKey,
+        IntPtr pPaddingInfo,
+        byte[] pbHashValue,
+        int cbHashValue,
+        byte[] pbSignature,
+        int cbSignature,
+        ref int pcbResult,
+        int dwFlags
+    );
+
+    [DllImport("ncrypt.dll", SetLastError = true)]
+    public static extern int NCryptExportKey(
+        IntPtr hKey,
+        IntPtr hExportKey,
+        [MarshalAs(UnmanagedType.LPWStr)]
+        string pszBlobType,
+        IntPtr pParameterList,
+        [MarshalAs(UnmanagedType.LPArray)]
+        byte[] pbOutput,
+        int cbOutput,
+        ref int pcbResult,
+        int dwFlags
+    );
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct BCRYPT_PKCS1_PADDING_INFO {
+        [MarshalAs(UnmanagedType.LPWStr)]
+        public string pszAlgId;
+    }
+}
+"@
+    }
+
+    function Get-Base64UrlEncode {
+        param([byte[]]$Bytes)
+        $base64 = [Convert]::ToBase64String($Bytes)
+        return $base64.Replace('+', '-').Replace('/', '_').Replace('=', '')
+    }
+
+    function Convert-GuidToLittleEndian {
+        param([Guid]$Guid)
+        $bytes = $Guid.ToByteArray()
+        return $bytes
+    }
+
+    function Get-UserHandleFromCert {
+        param($Certificate, $userId)
+
+        # Parse certificate subject
+        # Format is typically: CN={sid}/{unknown}/login.windows.net/{tenantId}/{upn}
+        $subject = $Certificate.Subject
+        Write-Verbose "Certificate Subject: $subject"
+
+        $parts = $subject -split '/'
+
+        if ($parts.Length -lt 3) {
+            throw "Cannot parse certificate subject. Expected format: CN={sid}/.../login.windows.net/{tenantId}/{upn}"
+        }
+
+        # The tenant ID is the second to last part of the subject
+        $tenantId = $parts[-2]
+        try {
+            $tenantGuid = [Guid]$tenantId
+        } catch {
+            throw "Failed to parse the tenant ID '$tenantId' from the certificate subject as a GUID."
+        }
+
+        if ([string]::IsNullOrWhiteSpace($userId)) {
+            # Derive the object ID from the user SID in the certificate subject (first part)
+            $sid = $parts[0] -replace '^CN=', ''
+            Write-Verbose "Deriving object ID from certificate user SID: $sid"
+            $userGuid = ConvertFrom-TTUserSid -Sid $sid
+            $userId = $userGuid.ToString()
+            Write-Host "$([char]0x2714) Derived object ID from certificate: $userId" -ForegroundColor Green
+        } else {
+            $userGuid = [Guid]$userId
+        }
+
+        Write-Verbose "Tenant ID: $tenantId"
+        Write-Verbose "User ID: $userId"
+
+        $tenantBytes = Convert-GuidToLittleEndian -Guid $tenantGuid
+        $userBytes = Convert-GuidToLittleEndian -Guid $userGuid
+
+        # Calculate userHandle: "ON:" + tenantId (LE) + SHA256(userId LE)
+        $userHandleBytes = [System.Collections.ArrayList]::new()
+        [void]$userHandleBytes.AddRange([byte[]][char[]]"ON:")
+        [void]$userHandleBytes.AddRange($tenantBytes)
+
+        # Calculate SHA256 of user ID bytes
+        $sha256 = [Security.Cryptography.SHA256]::Create()
+        $userHash = $sha256.ComputeHash($userBytes)
+        [void]$userHandleBytes.AddRange($userHash)
+        $sha256.Dispose()
+
+        $userHandle = Get-Base64UrlEncode -Bytes $userHandleBytes.ToArray()
+
+        Write-Verbose "User Handle: $userHandle"
+
+        return @{
+            TenantId   = $tenantId
+            UserId     = $userId
+            UserHandle = $userHandle
+        }
+    }
+
+    # Main execution
+    Write-Host "$([char]0x2718) Looking for Windows Hello certificate..." -ForegroundColor Cyan
+    $certs = Get-ChildItem Cert:\CurrentUser\My\ | Where-Object { $_.Subject -like "*login.windows.net*" }
+
+    if ($certs.Count -eq 0) {
+        throw "No Windows Hello certificate found"
+    }
+
+    $cert = $certs[0]
+    Write-Host "$([char]0x2714) Found certificate: $($cert.Subject)" -ForegroundColor Green
+
+    # Extract user info from certificate
+    $userInfo = Get-UserHandleFromCert -Certificate $cert -userId $UserId
+
+    # Get key provider info
+    $certHandle = $cert.Handle
+    $propSize = 0
+    $propId = 2  # CERT_KEY_PROV_INFO_PROP_ID
+
+    [void][NCrypt]::CertGetCertificateContextProperty($certHandle, $propId, [IntPtr]::Zero, [ref]$propSize)
+    $propBuffer = [Runtime.InteropServices.Marshal]::AllocHGlobal($propSize)
+    [void][NCrypt]::CertGetCertificateContextProperty($certHandle, $propId, $propBuffer, [ref]$propSize)
+
+    $keyProv = [Runtime.InteropServices.Marshal]::PtrToStructure($propBuffer, [Type][NCrypt+CRYPT_KEY_PROV_INFO])
+    [Runtime.InteropServices.Marshal]::FreeHGlobal($propBuffer)
+
+    Write-Verbose "Key Container: $($keyProv.pwszContainerName)"
+    Write-Verbose "Key Provider: $($keyProv.pwszProvName)"
+
+    # Open NCrypt storage provider and key
+    $phProvider = [IntPtr]::Zero
+    [void][NCrypt]::NCryptOpenStorageProvider([ref]$phProvider, $keyProv.pwszProvName, 0)
+
+    $phKey = [IntPtr]::Zero
+    [void][NCrypt]::NCryptOpenKey($phProvider, [ref]$phKey, $keyProv.pwszContainerName, 0, 0)
+
+    # Export public key for credential ID calculation
+    $pcbResult = 0
+    [void][NCrypt]::NCryptExportKey($phKey, [IntPtr]::Zero, "RSAPUBLICBLOB", [IntPtr]::Zero, $null, 0, [ref]$pcbResult, 0)
+    $pubkey = New-Object byte[] -ArgumentList $pcbResult
+    [void][NCrypt]::NCryptExportKey($phKey, [IntPtr]::Zero, "RSAPUBLICBLOB", [IntPtr]::Zero, $pubkey, $pubkey.Length, [ref]$pcbResult, 0)
+
+    # Calculate credential ID (SHA256 of public key)
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    $credIdHash = $sha256.ComputeHash($pubkey)
+    $sha256.Dispose()
+    $credentialId = Get-Base64UrlEncode -Bytes $credIdHash
+
+    Write-Host "$([char]0x2714) Credential ID: $credentialId" -ForegroundColor Green
+
+    # Base64 encode challenge
+    $challengebytes = [System.Text.Encoding]::UTF8.GetBytes($Challenge)
+    $challengeb64 = Get-Base64UrlEncode -Bytes $challengebytes
+
+    # Create clientDataJSON
+    $clientData = @{
+        type        = "webauthn.get"
+        challenge   = $challengeb64
+        origin      = $Origin
+        crossOrigin = $false
+    } | ConvertTo-Json -Compress
+
+    $clientDataBytes = [System.Text.Encoding]::UTF8.GetBytes($clientData)
+    $clientDataB64 = Get-Base64UrlEncode -Bytes $clientDataBytes
+
+    # Hash clientDataJSON
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    $clientDataHash = $sha256.ComputeHash($clientDataBytes)
+    $sha256.Dispose()
+
+    # Create authenticatorData
+    # RP ID hash (32 bytes) + flags (1 byte) + sign count (4 bytes) = 37 bytes
+    $rpIdBytes = [System.Text.Encoding]::UTF8.GetBytes($RpId)
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    $rpIdHash = $sha256.ComputeHash($rpIdBytes)
+    $sha256.Dispose()
+
+    $flags = 0x05  # UP (0x01) + UV (0x04)
+    $signCountBytes = [BitConverter]::GetBytes([int]$SignCount)
+    [Array]::Reverse($signCountBytes)  # Big-endian
+
+    $authenticatorData = [byte[]]::new(37)
+    [Array]::Copy($rpIdHash, 0, $authenticatorData, 0, 32)
+    $authenticatorData[32] = $flags
+    [Array]::Copy($signCountBytes, 0, $authenticatorData, 33, 4)
+
+    $authenticatorDataB64 = Get-Base64UrlEncode -Bytes $authenticatorData
+
+    # Create data to sign: authenticatorData || hash(clientDataJSON)
+    $toSign = [byte[]]::new($authenticatorData.Length + $clientDataHash.Length)
+    [Array]::Copy($authenticatorData, 0, $toSign, 0, $authenticatorData.Length)
+    [Array]::Copy($clientDataHash, 0, $toSign, $authenticatorData.Length, $clientDataHash.Length)
+
+    # Hash the data to sign
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    $hashToSign = $sha256.ComputeHash($toSign)
+    $sha256.Dispose()
+
+    Write-Host "$([char]0x2718) Signing assertion with Windows Hello key..." -ForegroundColor Cyan
+
+    # Sign with NCrypt
+    $paddingInfo = New-Object -TypeName 'NCrypt+BCRYPT_PKCS1_PADDING_INFO'
+    $paddingInfo.pszAlgId = "SHA256"
+    $pPtr = [Runtime.InteropServices.Marshal]::AllocHGlobal([Runtime.InteropServices.Marshal]::SizeOf($paddingInfo))
+    [Runtime.InteropServices.Marshal]::StructureToPtr($paddingInfo, $pPtr, $false)
+
+    $sigSize = 0
+    [void][NCrypt]::NCryptSignHash($phKey, $pPtr, $hashToSign, $hashToSign.Length, $null, 0, [ref]$sigSize, 2)
+
+    $signature = New-Object byte[] -ArgumentList $sigSize
+    [void][NCrypt]::NCryptSignHash($phKey, $pPtr, $hashToSign, $hashToSign.Length, $signature, $signature.Length, [ref]$sigSize, 2)
+
+    [Runtime.InteropServices.Marshal]::FreeHGlobal($pPtr)
+
+    $signatureB64 = Get-Base64UrlEncode -Bytes $signature
+
+    Write-Host "$([char]0x2714) Signature created" -ForegroundColor Green
+
+    # Construct the WebAuthn assertion response and return it as a compressed JSON string,
+    # so it can easily be transferred to the machine running Invoke-EntraIDPasskeyAssertionLogin
+    $assertion = [ordered]@{
+        id                = $credentialId
+        clientDataJSON    = $clientDataB64
+        authenticatorData = $authenticatorDataB64
+        signature         = $signatureB64
+        userHandle        = $userInfo.UserHandle
+    }
+
+    return ($assertion | ConvertTo-Json -Compress)
+}

--- a/modules/Invoke-EntraIDPasskeyAssertionLogin.ps1
+++ b/modules/Invoke-EntraIDPasskeyAssertionLogin.ps1
@@ -1,0 +1,423 @@
+<#
+.SYNOPSIS
+    Completes an Entra ID passkey (FIDO2) sign-in using a signed assertion.
+
+.DESCRIPTION
+    Submits a signed FIDO2 assertion (e.g. created with Get-WindowsHelloFidoAssertion) to
+    Entra ID and completes the sign-in flow, including interrupt handling (CMSI, KMSI and
+    ConvergedSignIn).
+
+    The command relies on the web session previously created by Get-EntraIDFido2Challenge in
+    the same PowerShell session ($global:Fido2WebSession, with the session information
+    attached as property Fido2SessionInfo). Both can be overridden with parameters.
+
+    By default the resulting ESTSAUTH cookie is exchanged for an access token and refresh
+    token (OutputType 'Token'). Use -OutputType ESTSAUTHCookie to return the raw ESTSAUTH
+    cookie value instead.
+
+.PARAMETER Assertion
+    The signed FIDO2 assertion as an object (id, clientDataJSON, authenticatorData,
+    signature, userHandle) or as a JSON string, e.g. from Get-WindowsHelloFidoAssertion.
+
+.PARAMETER WebSession
+    The web request session that requested the FIDO2 challenge.
+    Defaults to $global:Fido2WebSession.
+
+.PARAMETER SessionInfo
+    The parsed session information created by Get-EntraIDFido2Challenge.
+    Defaults to the Fido2SessionInfo property of the web session.
+
+.PARAMETER UserPrincipalName
+    The user principal name of the target user.
+    Defaults to the value stored in the session information.
+
+.PARAMETER OutputType
+    'Token' (default) exchanges the ESTSAUTH cookie for an access token and refresh token.
+    'ESTSAUTHCookie' returns the raw ESTSAUTH cookie value.
+
+.PARAMETER Client
+    The client used for the token exchange. Defaults to "MSTeams".
+
+.PARAMETER ClientID
+    A custom client ID used for the token exchange (Client 'Custom').
+
+.PARAMETER Resource
+    The resource for the token exchange. Defaults to "https://graph.microsoft.com".
+
+.PARAMETER Scope
+    The scope for the token exchange. Defaults to "openid offline_access".
+
+.PARAMETER RedirectUrl
+    The redirect URL for the token exchange.
+
+.PARAMETER Proxy
+    Optional proxy URL used for all web requests.
+
+.EXAMPLE
+    $challenge = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com"
+    $assertion = Get-WindowsHelloFidoAssertion -Challenge $challenge -UserId "00000000-0000-0000-0000-000000000002"
+    Invoke-EntraIDPasskeyAssertionLogin -Assertion $assertion
+    Completes the passkey sign-in and returns an access token and refresh token.
+
+.EXAMPLE
+    Invoke-EntraIDPasskeyAssertionLogin -Assertion $assertion -OutputType ESTSAUTHCookie
+    Completes the passkey sign-in and returns the ESTSAUTH cookie value.
+
+.NOTES
+    Part of TokenTacticsV2
+    https://github.com/f-bader/TokenTacticsV2
+#>
+function Invoke-EntraIDPasskeyAssertionLogin {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        $Assertion,
+
+        [Parameter(Mandatory = $false)]
+        [Microsoft.PowerShell.Commands.WebRequestSession]$WebSession = $global:Fido2WebSession,
+
+        [Parameter(Mandatory = $false)]
+        $SessionInfo,
+
+        [Alias('UserName')]
+        [Parameter(Mandatory = $false)]
+        [string]$UserPrincipalName,
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet('Token', 'ESTSAUTHCookie')]
+        [string]$OutputType = 'Token',
+
+        [Parameter(Mandatory = $false)]
+        [ValidateSet("MSTeams", "MSEdge", "AzurePowershell", "AzureManagement", "DeviceComplianceBypass", "Custom")]
+        [string]$Client = "MSTeams",
+
+        [Parameter(Mandatory = $false)]
+        [string]$ClientID,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Resource = "https://graph.microsoft.com",
+
+        [Parameter(Mandatory = $false)]
+        [string]$Scope = "openid offline_access",
+
+        [Parameter(Mandatory = $false)]
+        [string]$RedirectUrl = "https://login.microsoftonline.com/common/oauth2/nativeclient",
+
+        [Parameter(Mandatory = $false)]
+        [string]$Proxy
+    )
+
+    process {
+        # Normalize the assertion input (object or JSON string)
+        if ($Assertion -is [string]) {
+            try {
+                $Assertion = $Assertion | ConvertFrom-Json
+            } catch {
+                throw "Assertion could not be parsed as JSON. $($_.Exception.Message)"
+            }
+        }
+        foreach ($property in @('id', 'clientDataJSON', 'authenticatorData', 'signature', 'userHandle')) {
+            if ([string]::IsNullOrWhiteSpace($Assertion.$property)) {
+                throw "Assertion is missing required property '$property'."
+            }
+        }
+        $assertionJson = $Assertion | ConvertTo-Json -Compress -Depth 10
+
+        if (-not $WebSession) {
+            throw "No web session available. Run Get-EntraIDFido2Challenge first or provide -WebSession."
+        }
+        if (-not $SessionInfo) {
+            $SessionInfo = $WebSession.Fido2SessionInfo
+        }
+        if (-not $SessionInfo) {
+            throw "No session information available. Run Get-EntraIDFido2Challenge first or provide -SessionInfo."
+        }
+
+        # Note: an unbound [string] parameter is an empty string, not $null, so ?? cannot be used here
+        $targetUser = $UserPrincipalName
+        if ([string]::IsNullOrWhiteSpace($targetUser)) {
+            $targetUser = $SessionInfo.UserPrincipalName
+        }
+        if ([string]::IsNullOrWhiteSpace($targetUser)) {
+            throw "UserPrincipalName not found. Provide -UserPrincipalName or run Get-EntraIDFido2Challenge first."
+        }
+
+        # Configure Default Parameters
+        $PSDefaultParameterValues = @{}
+        $PSDefaultParameterValues.Add('Invoke-WebRequest:Verbose', $false)
+
+        if ($Proxy) {
+            Write-Verbose "$([char]0x2718) Setting proxy to $Proxy"
+            $PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy', $Proxy)
+        }
+
+        $session = $WebSession
+        $credentialsJson = $SessionInfo.oGetCredTypeResult.Credentials.FidoParams.AllowList -join ','
+
+        Write-Host "$([char]0x2718) Get required pre-information from microsoft.com..." -ForegroundColor Cyan
+        $verifyUrl = "https://login.microsoft.com/common/fido/get?uiflavor=Web"
+
+        # The fidoAssertion must be a JSON string *inside* the body
+        $bodyVerify = @{
+            allowedIdentities = 2
+            canary            = $SessionInfo.sFT
+            ServerChallenge   = $SessionInfo.sFT
+            postBackUrl       = $SessionInfo.urlPost
+            postBackUrlAad    = $SessionInfo.urlPostAad
+            postBackUrlMsa    = $SessionInfo.urlPostMsa
+            cancelUrl         = $SessionInfo.urlRefresh
+            resumeUrl         = $SessionInfo.urlResume
+            correlationId     = $SessionInfo.correlationId
+            credentialsJson   = $credentialsJson
+            ctx               = $SessionInfo.sCtx
+            username          = $targetUser
+            loginCanary       = $SessionInfo.canary
+        }
+
+        try {
+            Write-Verbose "$([char]0x2718) Submitting verification request ..."
+            Write-Debug "$($bodyVerify | ConvertTo-Json -Depth 10)"
+            $respVerify = Invoke-WebRequest -UseBasicParsing -Uri $verifyUrl -Method Post -Body $bodyVerify -WebSession $session
+
+            # Extract config from response headers/cookies
+            $respVerify.Content -match '{(.*)}' | Out-Null
+            $ResponseInformation = $Matches[0] | ConvertFrom-Json
+        } catch {
+            throw "Verification request failed: $($_.Exception.Message)"
+        }
+
+        $LoginUri = "https://login.microsoftonline.com/common/login"
+        $Payload = @{
+            type         = 23
+            ps           = 23
+            assertion    = $assertionJson
+            lmcCanary    = $ResponseInformation.sCrossDomainCanary
+            hpgrequestid = $ResponseInformation.sessionId
+            ctx          = $ResponseInformation.sCtx
+            canary       = $ResponseInformation.canary
+            flowToken    = $ResponseInformation.sFT
+        }
+
+        try {
+            Write-Host "$([char]0x2718) Submitting FIDO2 assertion to microsoftonline.com ..." -ForegroundColor Cyan
+            Write-Debug ($Payload | ConvertTo-Json -Depth 10)
+            $respFinalize = Invoke-WebRequest -UseBasicParsing -Uri $LoginUri -Method Post -Body $Payload -WebSession $session -MaximumRedirection 0 -SkipHttpErrorCheck -ErrorAction Stop
+            if ($respFinalize.Content -match '{(.*)}') {
+                $Debug = $Matches[0] | ConvertFrom-Json | ConvertTo-Json -Depth 10
+                Write-Debug "$([char]0x2718) Finalization Response: $Debug"
+            }
+        } catch {
+            # A redirect is an expected response when the assertion was accepted; the ESTS
+            # cookies are set on the session. Depending on the platform this surfaces as a
+            # redirection count error or an InvalidOperationException. Anything else is a
+            # real failure.
+            # Note: [regex]::IsMatch is used instead of -notmatch to avoid populating $Matches.
+            if (-not [regex]::IsMatch($_.Exception.Message, 'maximum redirection count|current state of the object')) {
+                throw "Finalization request failed: $($_.Exception.Message)"
+            }
+            Write-Verbose "$([char]0x2714) Assertion accepted (server responded with a redirect)."
+        }
+
+        $LoginUri = "https://login.microsoftonline.com/common/login?sso_reload=true"
+        $Payload = @{
+            type         = 23
+            ps           = 23
+            assertion    = $assertionJson
+            lmcCanary    = $ResponseInformation.sCrossDomainCanary
+            hpgrequestid = $ResponseInformation.sessionId
+            ctx          = $SessionInfo.sCtx
+            canary       = $SessionInfo.canary
+            flowToken    = $SessionInfo.oGetCredTypeResult.FlowToken
+        }
+
+        try {
+            Write-Host "$([char]0x2718) Submitting FIDO2 assertion to microsoftonline.com with sso_reload=true ..." -ForegroundColor Cyan
+            $respFinalize = Invoke-WebRequest -UseBasicParsing -Uri $LoginUri -Method Post -Body $Payload -WebSession $session -MaximumRedirection 0 -SkipHttpErrorCheck -ErrorAction Stop
+        } catch {
+            # A redirect is an expected response when the assertion was accepted; the ESTS
+            # cookies are set on the session. Depending on the platform this surfaces as a
+            # redirection count error or an InvalidOperationException. Anything else is a
+            # real failure.
+            # Note: [regex]::IsMatch is used instead of -notmatch to avoid populating $Matches.
+            if (-not [regex]::IsMatch($_.Exception.Message, 'maximum redirection count|current state of the object')) {
+                throw "Finalization request failed: $($_.Exception.Message)"
+            }
+            Write-Verbose "$([char]0x2714) Assertion accepted (server responded with a redirect)."
+        }
+
+        # $respFinalize can be null here if both submissions were answered with a redirect
+        $Debug = $null
+        if ($respFinalize.Content -match '{(.*)}') {
+            $Debug = $Matches[0] | ConvertFrom-Json
+        }
+        if ($Debug.pgid) {
+            Write-Host "$([char]0x2718) PageID: $($Debug.pgid)"
+            $CurrentPageId = $Debug.pgid
+        }
+        Write-Debug "$([char]0x2718) Finalization Response: $($Debug | ConvertTo-Json -Depth 10)"
+
+        # Interrupt Handling
+        $LoopCount = 0
+        while ($Debug.pgid -in @("CmsiInterrupt", "KmsiInterrupt", "ConvergedSignIn")) {
+            # Cleanup variables
+            Remove-Variable -Name respFinalize -ErrorAction SilentlyContinue
+            # Prevent infinite loops
+            if ($CurrentPageId -eq $LastPageId) {
+                Write-Warning "Stuck in interrupt loop on PageID: $($Debug.pgid). Exiting."
+                break
+            }
+            $LastPageId = $CurrentPageId
+
+            # Display debug info only on first loop
+            if ($LoopCount -eq 0) {
+                if ( -not [string]::IsNullOrWhiteSpace($Debug.sDeviceId)) {
+                    Write-Host "$([char]0x2718)  Device Id: $($Debug.sDeviceId)"
+                }
+                if ( -not [string]::IsNullOrWhiteSpace($Debug.correlationId)) {
+                    Write-Host "$([char]0x2718)  Correlation Id: $($Debug.correlationId)"
+                }
+                if ( -not [string]::IsNullOrWhiteSpace($Debug.sessionId)) {
+                    Write-Host "$([char]0x2718)  Session Id: $($Debug.sessionId)"
+                }
+                if ( -not [string]::IsNullOrWhiteSpace($Debug.sPOST_Username)) {
+                    Write-Host "$([char]0x2718)  Username: $($Debug.sPOST_Username)"
+                }
+            }
+            $LoopCount++
+
+            if ($LoopCount -gt 10) {
+                Write-Warning "Exceeded maximum interrupt handling attempts. Exiting."
+                break
+            }
+
+            # CMSI (consent) interrupt
+            if ($Debug.pgid -eq "CmsiInterrupt") {
+                Write-Host "$([char]0x2718)  AADSTS50199: CmsiInterrupt"
+                Write-Host "   For security reasons, user confirmation is required for this application: $($Debug.sAppName)."
+                Write-Host "$([char]0x2718)  urlPost URL: $($Debug.urlPost)"
+                $Uri = "https://login.microsoftonline.com/appverify"
+                $Payload = @{
+                    "ContinueAuth"    = "true"
+                    "i19"             = "$(Get-Random -Minimum 1000 -Maximum 9999)"
+                    "canary"          = $Debug.canary
+                    "iscsrfspeedbump" = "false"
+                    "flowToken"       = $Debug.sFT
+                    "hpgrequestid"    = $Debug.correlationId
+                    "ctx"             = $Debug.sCtx
+                }
+
+                try {
+                    Write-Host "$([char]0x2718) Submitting CMSI response to microsoftonline.com ..." -ForegroundColor Cyan
+                    $respFinalize = Invoke-WebRequest -UseBasicParsing -Uri $Uri -Method Post -Body $Payload -WebSession $session -SkipHttpErrorCheck -MaximumRedirection 10
+                } catch {
+                    Write-Warning "CMSI request failed; checking previous response for success. Error: $($_.Exception.Message)"
+                }
+            }
+
+            # KMSI (keep me signed in) interrupt
+            if ($Debug.pgid -eq "KmsiInterrupt") {
+                Write-Host "$([char]0x2718) Handling KMSI prompt..." -ForegroundColor Cyan
+                $PayloadKMSI = @{
+                    LoginOptions = 1
+                    type         = 28
+                    ctx          = $Debug.sCtx
+                    hpgrequestid = $Debug.correlationId
+                    flowToken    = $Debug.sFT
+                    canary       = $Debug.canary
+                    i19          = 4130
+                }
+
+                try {
+                    $Uri = "https://login.microsoftonline.com/kmsi"
+                    Write-Host "$([char]0x2718) Submitting KMSI response to microsoftonline.com ..." -ForegroundColor Cyan
+                    $respFinalize = Invoke-WebRequest -UseBasicParsing -Uri $Uri -Method Post -Body $PayloadKMSI -WebSession $session
+                    Write-Debug "$([char]0x2718) KMSI Response: $($respFinalize | Out-String )"
+                } catch {
+                    Write-Warning "KMSI request failed; checking previous response for success. Error: $($_.Exception.Message)"
+                }
+            }
+
+            # ConvergedSignIn interrupt
+            if ($Debug.pgid -eq "ConvergedSignIn") {
+                Write-Output "$([char]0x2718)  ConvergedSignIn - Attempting to continue sign-in flow"
+                $SessionId = $($Debug.arrSessions[0].id) ?? $Debug.sessionId
+                try {
+                    $Uri = $Debug.urlLogin + "&sessionid=$($SessionId)"
+                    Write-Host "$([char]0x2718) Submitting ConvergedSignIn request to microsoftonline.com ..." -ForegroundColor Cyan
+                    Write-Verbose "$([char]0x2718) ConvergedSignIn URL: $Uri"
+                    $respFinalize = Invoke-WebRequest -UseBasicParsing -Uri $Uri -Method Get -WebSession $session
+                } catch {
+                    Write-Warning "ConvergedSignIn request failed; checking previous response for success. Error: $($_.Exception.Message)"
+                }
+            }
+
+            Remove-Variable -Name Debug -ErrorAction SilentlyContinue
+            if ( $respFinalize.Content -match '{(.*)}' ) {
+                try {
+                    $Debug = $Matches[0] | ConvertFrom-Json
+                } catch {
+                    Write-Warning "Failed to parse JSON response during interrupt handling. Exiting loop."
+                    break
+                }
+                if ($Debug.pgid) {
+                    Write-Host "$([char]0x2718) PageID: $($Debug.pgid)"
+                    $CurrentPageId = $Debug.pgid
+                }
+                Write-Debug "$([char]0x2718) Full Response: $($Debug | ConvertTo-Json -Depth 10)"
+            } else {
+                Write-Debug "$([char]0x2718) No JSON response received; exiting interrupt handling loop."
+                Write-Debug "$([char]0x2718) Last Response: $($respFinalize) ..."
+                break
+            }
+        }
+
+        if ($respFinalize.Error) {
+            Write-Error "Login Error: $($respFinalize.Error.Message)"
+        } elseif ( $session.Cookies.GetCookies("https://login.microsoftonline.com") | Where-Object Name -Like "ESTS*") {
+            Write-Host "$([char]0x2714) Login Successful!" -ForegroundColor Green
+            $ESTSAUTH = $session.Cookies.GetCookies("https://login.microsoftonline.com") | Where-Object Name -EQ "ESTSAUTH"
+            $ESTSAUTHPERSISTENT = $session.Cookies.GetCookies("https://login.microsoftonline.com") | Where-Object Name -EQ "ESTSAUTHPERSISTENT"
+            $ESTSAUTHLIGHT = $session.Cookies.GetCookies("https://login.microsoftonline.com") | Where-Object Name -EQ "ESTSAUTHLIGHT"
+            # Get  ESTS cookie with longest value (usually ESTSAUTH or ESTSAUTHPERSISTENT)
+            $ests = @($ESTSAUTH, $ESTSAUTHPERSISTENT, $ESTSAUTHLIGHT) | Sort-Object { $_.Value.Length } -Descending | Select-Object -First 1
+            if (-not $ests) {
+                throw "Login succeeded but no ESTSAUTH cookie was found in the session."
+            }
+
+            if ($OutputType -eq 'ESTSAUTHCookie') {
+                Write-Host "$([char]0x26BF) ESTSAUTH Cookie: $($ests.Value.Substring(0, 20))... saved as `$global:ESTSAUTH" -ForegroundColor Gray
+                $global:ESTSAUTH = $ests.Value
+                Write-Host "$([char]0x26BF) Session saved as `$global:webSession for reuse in other functions." -ForegroundColor Gray
+                $global:webSession = $session
+                return $ests.Value
+            }
+
+            # Default: exchange the ESTSAUTH cookie for an access token and refresh token
+            $TokenParameters = @{
+                CookieValue = $ests.Value
+                Resource    = $Resource
+                Scope       = $Scope
+                RedirectUrl = $RedirectUrl
+                Client      = $Client
+                Verbose     = $VerbosePreference
+            }
+            if ($ests.Name -in @('ESTSAUTH', 'ESTSAUTHPERSISTENT')) {
+                $TokenParameters.Add('ESTSCookieType', $ests.Name)
+            }
+            if ($ClientID) {
+                $TokenParameters.Add('ClientID', $ClientID)
+            }
+            if ($Proxy) {
+                $TokenParameters.Add('Proxy', $Proxy)
+            }
+            Get-EntraIDTokenFromESTSCookie @TokenParameters
+            return $global:response
+        } else {
+            Write-Warning "Flow finished but success state is unclear. Saved session for inspection as `$global:webSession."
+            if ($respFinalize.Content -match '{(.*)}') {
+                $Matches[0] | ConvertFrom-Json | ConvertTo-Json -Depth 10
+            }
+            $global:webSession = $session
+        }
+    }
+}

--- a/modules/Invoke-EntraIDPasskeyAssertionLogin.ps1
+++ b/modules/Invoke-EntraIDPasskeyAssertionLogin.ps1
@@ -7,9 +7,9 @@
     Entra ID and completes the sign-in flow, including interrupt handling (CMSI, KMSI and
     ConvergedSignIn).
 
-    The command relies on the web session previously created by Get-EntraIDFido2Challenge in
-    the same PowerShell session ($global:Fido2WebSession, with the session information
-    attached as property Fido2SessionInfo). Both can be overridden with parameters.
+    The command accepts the structured flow state returned by Get-EntraIDFido2Challenge or falls
+    back to the legacy $global:Fido2WebSession state. Postback URLs are taken from the Entra flow
+    state instead of being hard-coded.
 
     By default the resulting ESTSAUTH cookie is exchanged for an access token and refresh
     token (OutputType 'Token'). Use -OutputType ESTSAUTHCookie to return the raw ESTSAUTH
@@ -27,6 +27,10 @@
     The parsed session information created by Get-EntraIDFido2Challenge.
     Defaults to the Fido2SessionInfo property of the web session.
 
+.PARAMETER FlowState
+    Structured flow state returned by Get-EntraIDFido2Challenge. Its session, OAuth settings and
+    session information take precedence over global state.
+
 .PARAMETER UserPrincipalName
     The user principal name of the target user.
     Defaults to the value stored in the session information.
@@ -36,7 +40,7 @@
     'ESTSAUTHCookie' returns the raw ESTSAUTH cookie value.
 
 .PARAMETER Client
-    The client used for the token exchange. Defaults to "MSTeams".
+    The built-in client used for the OAuth/token exchange. Names mirror Invoke-RefreshToToken.ps1.
 
 .PARAMETER ClientID
     A custom client ID used for the token exchange (Client 'Custom').
@@ -48,15 +52,34 @@
     The scope for the token exchange. Defaults to "openid offline_access".
 
 .PARAMETER RedirectUrl
-    The redirect URL for the token exchange.
+    The redirect URL for the token exchange. When omitted, the preferred registered redirect URI
+    for the effective client ID is selected; an explicit value overrides it.
+
+.PARAMETER Tenant
+    Tenant segment used by the OAuth flow.
+
+.PARAMETER Authority
+    Login authority host. Defaults to login.microsoftonline.com.
+
+.PARAMETER UseV1Endpoint
+    Use the v1 OAuth token model and resource parameter.
+
+.PARAMETER UseCAE
+    Request the CAE cp1 claim for v2 OAuth.
+
+.PARAMETER UseCodeVerifier
+    Enable PKCE for the OAuth flow.
+
+.PARAMETER CodeVerifier
+    PKCE verifier to use when redeeming an authorization code.
 
 .PARAMETER Proxy
     Optional proxy URL used for all web requests.
 
 .EXAMPLE
-    $challenge = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com"
-    $assertion = Get-WindowsHelloFidoAssertion -Challenge $challenge -UserId "00000000-0000-0000-0000-000000000002"
-    Invoke-EntraIDPasskeyAssertionLogin -Assertion $assertion
+    $flow = Get-EntraIDFido2Challenge -UserPrincipalName "user@contoso.com"
+    $assertion = Get-WindowsHelloFidoAssertion -Challenge $flow.Challenge -UserId "00000000-0000-0000-0000-000000000002"
+    Invoke-EntraIDPasskeyAssertionLogin -FlowState $flow -Assertion $assertion
     Completes the passkey sign-in and returns an access token and refresh token.
 
 .EXAMPLE
@@ -74,10 +97,13 @@ function Invoke-EntraIDPasskeyAssertionLogin {
         $Assertion,
 
         [Parameter(Mandatory = $false)]
-        [Microsoft.PowerShell.Commands.WebRequestSession]$WebSession = $global:Fido2WebSession,
+        [Microsoft.PowerShell.Commands.WebRequestSession]$WebSession,
 
         [Parameter(Mandatory = $false)]
         $SessionInfo,
+
+        [Parameter(Mandatory = $false)]
+        $FlowState,
 
         [Alias('UserName')]
         [Parameter(Mandatory = $false)]
@@ -88,8 +114,8 @@ function Invoke-EntraIDPasskeyAssertionLogin {
         [string]$OutputType = 'Token',
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet("MSTeams", "MSEdge", "AzurePowershell", "AzureManagement", "DeviceComplianceBypass", "Custom")]
-        [string]$Client = "MSTeams",
+        [ValidateSet('Substrate','MSManage','MSTeams','OfficeManagement','Outlook','MSGraph','Graph','OfficeApps','AzureCoreManagement','AzureStorage','AzureKeyVault','AzureManagement','MAM','DODMSGraph','SharePoint','OneDrive','Yammer','DeviceRegistration','Custom')]
+        [string]$Client = "MSGraph",
 
         [Parameter(Mandatory = $false)]
         [string]$ClientID,
@@ -98,10 +124,28 @@ function Invoke-EntraIDPasskeyAssertionLogin {
         [string]$Resource = "https://graph.microsoft.com",
 
         [Parameter(Mandatory = $false)]
-        [string]$Scope = "openid offline_access",
+        [string]$Scope,
 
         [Parameter(Mandatory = $false)]
-        [string]$RedirectUrl = "https://login.microsoftonline.com/common/oauth2/nativeclient",
+        [string]$RedirectUrl,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Tenant = 'organizations',
+
+        [Parameter(Mandatory = $false)]
+        [string]$Authority = 'login.microsoftonline.com',
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseV1Endpoint,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseCAE,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$UseCodeVerifier,
+
+        [Parameter(Mandatory = $false)]
+        [string]$CodeVerifier,
 
         [Parameter(Mandatory = $false)]
         [string]$Proxy
@@ -123,14 +167,50 @@ function Invoke-EntraIDPasskeyAssertionLogin {
         }
         $assertionJson = $Assertion | ConvertTo-Json -Compress -Depth 10
 
+        if ($FlowState) {
+            if (-not $WebSession) { $WebSession = $FlowState.WebSession }
+            if (-not $SessionInfo) { $SessionInfo = $FlowState.SessionInformation }
+            if (-not $SessionInfo) { $SessionInfo = $FlowState.SessionInfo }
+            if ($FlowState.OAuth) {
+                if ([string]::IsNullOrWhiteSpace($ClientID)) { $ClientID = $FlowState.OAuth.ClientID }
+                if ([string]::IsNullOrWhiteSpace($Scope)) { $Scope = $FlowState.OAuth.Scope }
+                if ($FlowState.OAuth.Resource) { $Resource = $FlowState.OAuth.Resource }
+                if ([string]::IsNullOrWhiteSpace($RedirectUrl)) { $RedirectUrl = $FlowState.OAuth.RedirectUrl }
+                if ($FlowState.OAuth.UseV1Endpoint) { $UseV1Endpoint = $true }
+                if ($FlowState.OAuth.UseCAE) { $UseCAE = $true }
+                if ($FlowState.OAuth.UseCodeVerifier) { $UseCodeVerifier = $true }
+                if ([string]::IsNullOrWhiteSpace($CodeVerifier)) { $CodeVerifier = $FlowState.OAuth.CodeVerifier }
+            }
+        }
+        if (-not $WebSession) { $WebSession = $global:Fido2WebSession }
+        if (-not $SessionInfo -and $WebSession) { $SessionInfo = $WebSession.Fido2SessionInfo }
+
         if (-not $WebSession) {
             throw "No web session available. Run Get-EntraIDFido2Challenge first or provide -WebSession."
         }
         if (-not $SessionInfo) {
-            $SessionInfo = $WebSession.Fido2SessionInfo
-        }
-        if (-not $SessionInfo) {
             throw "No session information available. Run Get-EntraIDFido2Challenge first or provide -SessionInfo."
+        }
+
+        $effectiveClient = $Client
+        if ($FlowState -and $FlowState.OAuth -and $FlowState.OAuth.Client) {
+            $effectiveClient = $FlowState.OAuth.Client
+        }
+        $resolvedOAuth = Resolve-TTEntraOAuthClient `
+            -Client $effectiveClient `
+            -ClientID $ClientID `
+            -Scope $Scope `
+            -Resource $Resource `
+            -RedirectUrl $RedirectUrl `
+            -UseV1Endpoint:$UseV1Endpoint
+        if ([string]::IsNullOrWhiteSpace($ClientID)) { $ClientID = $resolvedOAuth.ClientID }
+        if ([string]::IsNullOrWhiteSpace($Scope)) { $Scope = $resolvedOAuth.Scope }
+        if ([string]::IsNullOrWhiteSpace($Scope)) { $Scope = 'openid offline_access' }
+        if ($resolvedOAuth.Resource) { $Resource = $resolvedOAuth.Resource }
+        if ($resolvedOAuth.UseV1Endpoint) { $UseV1Endpoint = $true }
+        if ([string]::IsNullOrWhiteSpace($RedirectUrl)) { $RedirectUrl = $resolvedOAuth.RedirectUrl }
+        if ([string]::IsNullOrWhiteSpace($RedirectUrl)) {
+            throw "No redirect URI is known for client ID '$ClientID'. Provide -RedirectUrl for this app registration."
         }
 
         # Note: an unbound [string] parameter is an empty string, not $null, so ?? cannot be used here
@@ -152,6 +232,10 @@ function Invoke-EntraIDPasskeyAssertionLogin {
         }
 
         $session = $WebSession
+        $flowAuthority = $Authority
+        if ($FlowState -and $FlowState.OAuth -and $FlowState.OAuth.Authority) {
+            $flowAuthority = $FlowState.OAuth.Authority
+        }
         $credentialsJson = $SessionInfo.oGetCredTypeResult.Credentials.FidoParams.AllowList -join ','
 
         Write-Host "$([char]0x2718) Get required pre-information from microsoft.com..." -ForegroundColor Cyan
@@ -186,7 +270,9 @@ function Invoke-EntraIDPasskeyAssertionLogin {
             throw "Verification request failed: $($_.Exception.Message)"
         }
 
-        $LoginUri = "https://login.microsoftonline.com/common/login"
+        $postbackUrl = $SessionInfo.urlPost
+        if ($FlowState -and $FlowState.PostbackUrl) { $postbackUrl = $FlowState.PostbackUrl }
+        $LoginUri = Resolve-TTEntraPostbackUri -PostbackUrl $postbackUrl -Authority $flowAuthority
         $Payload = @{
             type         = 23
             ps           = 23
@@ -218,7 +304,7 @@ function Invoke-EntraIDPasskeyAssertionLogin {
             Write-Verbose "$([char]0x2714) Assertion accepted (server responded with a redirect)."
         }
 
-        $LoginUri = "https://login.microsoftonline.com/common/login?sso_reload=true"
+        $LoginUri = Add-TTUriQueryParameter -Uri $LoginUri -Name 'sso_reload' -Value 'true'
         $Payload = @{
             type         = 23
             ps           = 23
@@ -393,12 +479,17 @@ function Invoke-EntraIDPasskeyAssertionLogin {
             }
 
             # Default: exchange the ESTSAUTH cookie for an access token and refresh token
+            $exchangeClient = $Client
+            $supportedCookieClients = @('MSTeams', 'MSEdge', 'AzurePowershell', 'AzureManagement', 'DeviceComplianceBypass', 'Custom')
+            if ($FlowState -or $exchangeClient -notin $supportedCookieClients) {
+                $exchangeClient = 'Custom'
+            }
             $TokenParameters = @{
                 CookieValue = $ests.Value
                 Resource    = $Resource
                 Scope       = $Scope
                 RedirectUrl = $RedirectUrl
-                Client      = $Client
+                Client      = $exchangeClient
                 Verbose     = $VerbosePreference
             }
             if ($ests.Name -in @('ESTSAUTH', 'ESTSAUTHPERSISTENT')) {
@@ -409,6 +500,12 @@ function Invoke-EntraIDPasskeyAssertionLogin {
             }
             if ($Proxy) {
                 $TokenParameters.Add('Proxy', $Proxy)
+            }
+            if ($UseV1Endpoint) { $TokenParameters.Add('UseV1Endpoint', $true) }
+            if ($UseCAE) { $TokenParameters.Add('UseCAE', $true) }
+            if ($UseCodeVerifier) {
+                $TokenParameters.Add('UseCodeVerifier', $true)
+                if ($CodeVerifier) { $TokenParameters.Add('CodeVerifier', $CodeVerifier) }
             }
             Get-EntraIDTokenFromESTSCookie @TokenParameters
             return $global:response

--- a/modules/New-EntraIDOAuthUrl.ps1
+++ b/modules/New-EntraIDOAuthUrl.ps1
@@ -1,0 +1,361 @@
+<#
+    Private OAuth helpers shared by the FIDO cmdlets.
+
+    The client names intentionally mirror the public refresh-token cmdlets in
+    Invoke-RefreshToToken.ps1.  These functions are dot-sourced by the module,
+    but are not exported.
+#>
+
+$script:TTDefaultOAuthRedirectUri = 'https://login.microsoftonline.com/common/oauth2/nativeclient'
+
+# Redirect URIs belong to the app registration, not to the requested resource
+# or scope. These values are the preferred non-interactive redirect URIs from
+# the ROADtools first-party client data.
+$script:TTClientRedirectUris = @{
+    '1b730954-1685-4b74-9bfd-dac224a7b894' = $script:TTDefaultOAuthRedirectUri # aadps
+    '04b07795-8ddb-461a-bbee-02f9e1bf7b46' = $script:TTDefaultOAuthRedirectUri # azcli
+    '1fec8e78-bce4-4aaf-ab1b-5451cc387264' = $script:TTDefaultOAuthRedirectUri # teams
+    '1950a258-227b-4e31-a9cf-717495945fc2' = $script:TTDefaultOAuthRedirectUri # azps
+    'ecd6b820-32c2-49b6-98a6-444530e5a77a' = $script:TTDefaultOAuthRedirectUri # msedge
+    '29d9ed98-a469-4536-ade2-f981bc1d605e' = 'ms-appx-web://Microsoft.AAD.BrokerPlugin/DRSFF' # msbroker
+    '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223' = 'ms-appx-web://Microsoft.AAD.BrokerPlugin/9ba1a5c7-f17a-4de9-a1f1-6178c8d51223' # companyportal
+    'c44b4083-3bb0-49c1-b47d-974e53cbdf3c' = 'https://startups.portal.azure.com/auth/login/' # azureportal
+    'd3590ed6-52b3-4102-aeff-aad2292ab01c' = 'ms-appx-web://Microsoft.AAD.BrokerPlugIn/S-1-15-2-1479478596-3248452454-924133441-2206841801-2812823084-3237817612-3652912309'
+    '00b41c95-dab0-4487-9791-b9d2c32c80f2' = 'msauth://com.ms.office365admin/Ac5NobvxUHqRzkP59tdeFTg49D4='
+    'ab9b8c07-8f02-4f72-87fa-80105867a763' = $script:TTDefaultOAuthRedirectUri
+    '6c7e8096-f593-4d72-807f-a5f86dcc9c77' = 'urn:ietf:wg:oauth:2.0:oob'
+    '9bc3ab49-b65d-410a-85ad-de819febfddc' = 'http://localhost'
+}
+
+$script:TTBuiltInOAuthClients = [ordered]@{
+    Substrate = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://substrate.office.com/.default offline_access openid'
+    }
+    MSManage = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://enrollment.manage.microsoft.com/.default offline_access openid'
+    }
+    MSTeams = @{
+        ClientID = '1fec8e78-bce4-4aaf-ab1b-5451cc387264'
+        Scope    = 'https://api.spaces.skype.com/.default offline_access openid'
+    }
+    OfficeManagement = @{
+        ClientID = '00b41c95-dab0-4487-9791-b9d2c32c80f2'
+        Scope    = 'https://manage.office.com/.default offline_access openid'
+    }
+    Outlook = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://outlook.office365.com/.default offline_access openid'
+    }
+    MSGraph = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://graph.microsoft.com/.default offline_access openid'
+    }
+    Graph = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://graph.windows.net/.default offline_access openid'
+    }
+    OfficeApps = @{
+        ClientID = 'ab9b8c07-8f02-4f72-87fa-80105867a763'
+        Scope    = 'https://officeapps.live.com/.default offline_access openid'
+    }
+    AzureCoreManagement = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://management.core.windows.net/.default offline_access openid'
+    }
+    AzureStorage = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://storage.azure.com/.default offline_access openid'
+    }
+    AzureKeyVault = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://vault.azure.net/.default offline_access openid'
+    }
+    AzureManagement = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://management.azure.com/.default offline_access openid'
+    }
+    MAM = @{
+        ClientID = '6c7e8096-f593-4d72-807f-a5f86dcc9c77'
+        Scope    = 'https://intunemam.microsoftonline.com/.default offline_access openid'
+    }
+    DODMSGraph = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://dod-graph.microsoft.us/.default offline_access openid'
+        Authority = 'login.microsoftonline.us'
+    }
+    SharePoint = @{
+        ClientID = '9bc3ab49-b65d-410a-85ad-de819febfddc'
+        ScopeTemplate = 'https://{0}{1}.sharepoint.com/Sites.FullControl.All offline_access openid'
+    }
+    OneDrive = @{
+        ClientID = 'ab9b8c07-8f02-4f72-87fa-80105867a763'
+        Scope    = 'https://officeapps.live.com/.default offline_access openid'
+    }
+    Yammer = @{
+        ClientID = 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        Scope    = 'https://www.yammer.com/.default offline_access openid'
+    }
+    DeviceRegistration = @{
+        ClientID = '1b730954-1685-4b74-9bfd-dac224a7b894'
+        Scope    = 'openid'
+        Resource = '01cb2876-7ebd-4aa4-9cc9-d28bd4d359a9'
+        UseV1Endpoint = $true
+    }
+}
+
+function Get-TTEntraOAuthClientNames {
+    return @($script:TTBuiltInOAuthClients.Keys) + 'Custom'
+}
+
+function Resolve-TTEntraOAuthClient {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Client,
+        [string]$ClientID,
+        [string]$Scope,
+        [string]$Resource,
+        [string]$RedirectUrl,
+        [string]$SharePointTenantName,
+        [switch]$SharePointUseAdmin,
+        [switch]$UseV1Endpoint
+    )
+
+    if ($Client -eq 'Custom') {
+        if ([string]::IsNullOrWhiteSpace($ClientID)) {
+            throw 'ClientID must be provided for Custom client.'
+        }
+        if ([string]::IsNullOrWhiteSpace($Scope)) {
+            throw 'Scope must be provided for Custom client.'
+        }
+
+        $resolvedRedirect = if ([string]::IsNullOrWhiteSpace($RedirectUrl)) {
+            $script:TTClientRedirectUris[$ClientID]
+        } else {
+            $RedirectUrl
+        }
+
+        return [PSCustomObject]@{
+            Client         = $Client
+            ClientID       = $ClientID
+            Scope          = $Scope
+            Resource       = $Resource
+            RedirectUrl     = $resolvedRedirect
+            UseV1Endpoint  = $UseV1Endpoint.IsPresent
+        }
+    }
+
+    if (-not $script:TTBuiltInOAuthClients.Contains($Client)) {
+        throw "Unsupported OAuth client '$Client'. Supported clients: $((Get-TTEntraOAuthClientNames) -join ', ')."
+    }
+
+    $definition = $script:TTBuiltInOAuthClients[$Client]
+    $resolvedScope = $Scope
+    if ([string]::IsNullOrWhiteSpace($resolvedScope)) {
+        if ($definition.ScopeTemplate) {
+            if ([string]::IsNullOrWhiteSpace($SharePointTenantName)) {
+                throw 'SharePointTenantName must be provided for the SharePoint client.'
+            }
+            $adminSuffix = if ($SharePointUseAdmin) { '-admin' } else { '' }
+            $resolvedScope = [string]::Format($definition.ScopeTemplate, $SharePointTenantName, $adminSuffix)
+        } else {
+            $resolvedScope = $definition.Scope
+        }
+    }
+
+    $resolvedResource = if ([string]::IsNullOrWhiteSpace($Resource)) { $definition.Resource } else { $Resource }
+    $resolvedUseV1 = $UseV1Endpoint.IsPresent -or [bool]$definition.UseV1Endpoint
+    $resolvedClientId = if ([string]::IsNullOrWhiteSpace($ClientID)) { $definition.ClientID } else { $ClientID }
+    $resolvedRedirect = if ([string]::IsNullOrWhiteSpace($RedirectUrl)) {
+        $script:TTClientRedirectUris[$resolvedClientId]
+    } else {
+        $RedirectUrl
+    }
+
+    [PSCustomObject]@{
+        Client         = $Client
+        ClientID       = $resolvedClientId
+        Scope          = $resolvedScope
+        Resource       = $resolvedResource
+        RedirectUrl     = $resolvedRedirect
+        UseV1Endpoint  = $resolvedUseV1
+        Authority      = $definition.Authority
+    }
+}
+
+function Add-TTUriQueryParameter {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Uri,
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    $builder = [System.UriBuilder]$Uri
+    $query = [System.Web.HttpUtility]::ParseQueryString($builder.Query)
+    $query.Set($Name, $Value)
+    $builder.Query = $query.ToString()
+    return $builder.Uri.AbsoluteUri
+}
+
+function Resolve-TTEntraPostbackUri {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$PostbackUrl,
+        [string]$Authority = 'login.microsoftonline.com'
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PostbackUrl)) {
+        throw 'The FIDO flow did not provide a postback URL (urlPost).'
+    }
+
+    $absoluteUri = $null
+    if ([Uri]::TryCreate($PostbackUrl, [UriKind]::Absolute, [ref]$absoluteUri) -and
+        $absoluteUri.Scheme -in @('http', 'https')) {
+        if ($absoluteUri.Host -notmatch '(^|\.)login\.microsoft\.com$' -and
+            $absoluteUri.Host -notmatch '(^|\.)login\.microsoftonline\.(com|us)$') {
+            throw "The FIDO postback URL must target a Microsoft login host, not '$($absoluteUri.Host)'."
+        }
+        return $absoluteUri.AbsoluteUri
+    }
+
+    $baseUri = [Uri]::new("https://$Authority")
+    try {
+        return [Uri]::new($baseUri, $PostbackUrl).AbsoluteUri
+    } catch {
+        throw "Invalid FIDO postback URL '$PostbackUrl'. $($_.Exception.Message)"
+    }
+}
+
+function New-TTEntraAuthorizationUrl {
+    [CmdletBinding()]
+    param(
+        [ValidateSet('Substrate','MSManage','MSTeams','OfficeManagement','Outlook','MSGraph','Graph','OfficeApps','AzureCoreManagement','AzureStorage','AzureKeyVault','AzureManagement','MAM','DODMSGraph','SharePoint','OneDrive','Yammer','DeviceRegistration','Custom')]
+        [string]$Client = 'MSGraph',
+        [string]$ClientID,
+        [string]$Tenant = 'organizations',
+        [string]$Authority = 'login.microsoftonline.com',
+        [string]$RedirectUrl,
+        [string]$Scope,
+        [string]$Resource,
+        [string]$SharePointTenantName,
+        [switch]$SharePointUseAdmin,
+        [switch]$UseV1Endpoint,
+        [switch]$UseCAE,
+        [switch]$UseCodeVerifier,
+        [string]$CodeVerifier,
+        [string]$AuthorizationCodeState,
+        [string]$Username,
+        [string]$AuthUrl
+    )
+
+    $resolved = Resolve-TTEntraOAuthClient `
+        -Client $Client `
+        -ClientID $ClientID `
+        -Scope $Scope `
+        -Resource $Resource `
+        -RedirectUrl $RedirectUrl `
+        -SharePointTenantName $SharePointTenantName `
+        -SharePointUseAdmin:$SharePointUseAdmin `
+        -UseV1Endpoint:$UseV1Endpoint
+    if ($resolved.Authority -and $Authority -eq 'login.microsoftonline.com') {
+        $Authority = $resolved.Authority
+    }
+    if ([string]::IsNullOrWhiteSpace($AuthorizationCodeState)) {
+        $AuthorizationCodeState = [Guid]::NewGuid().ToString()
+    }
+    if ($UseCodeVerifier -and [string]::IsNullOrWhiteSpace($CodeVerifier)) {
+        $CodeVerifier = Get-TTCodeVerifier
+    }
+
+    if ($AuthUrl) {
+        try {
+            $builder = [System.UriBuilder]$AuthUrl
+            $query = [System.Web.HttpUtility]::ParseQueryString($builder.Query)
+        } catch {
+            throw "Invalid auth URL format. $($_.Exception.Message)"
+        }
+        if ($builder.Scheme -ne 'https' -or $builder.Host -notmatch '(^|\.)login\.microsoftonline\.(com|us)$') {
+            throw "Auth URL must start with 'https://login.microsoftonline.com/' or use the login.microsoftonline.us authority."
+        }
+    } else {
+        $selectedRedirect = if ([string]::IsNullOrWhiteSpace($RedirectUrl)) {
+            $resolved.RedirectUrl
+        } else {
+            $RedirectUrl
+        }
+        if ([string]::IsNullOrWhiteSpace($selectedRedirect)) {
+            throw "No redirect URI is known for client ID '$($resolved.ClientID)'. Provide -RedirectUrl for this app registration."
+        }
+        $endpoint = if ($resolved.UseV1Endpoint) { 'oauth2/authorize' } else { 'oauth2/v2.0/authorize' }
+        $builder = [System.UriBuilder]::new('https', $Authority, 443, "$Tenant/$endpoint")
+        $query = [System.Web.HttpUtility]::ParseQueryString('')
+        $query.Set('response_type', 'code')
+        $query.Set('redirect_uri', $selectedRedirect)
+        $query.Set('state', $AuthorizationCodeState)
+        if ($resolved.UseV1Endpoint -and $resolved.Resource) {
+            $query.Set('resource', $resolved.Resource)
+        }
+        if ($resolved.Scope) {
+            $query.Set('scope', $resolved.Scope)
+        }
+        $query.Set('client_id', $resolved.ClientID)
+    }
+
+    if (-not $query.Get('response_type')) { $query.Set('response_type', 'code') }
+    if (-not $query.Get('state')) { $query.Set('state', $AuthorizationCodeState) }
+    if (-not $query.Get('client_id')) { $query.Set('client_id', $resolved.ClientID) }
+    if (-not $query.Get('redirect_uri')) {
+        $selectedRedirect = if ([string]::IsNullOrWhiteSpace($RedirectUrl)) { $resolved.RedirectUrl } else { $RedirectUrl }
+        if (-not [string]::IsNullOrWhiteSpace($selectedRedirect)) {
+            $query.Set('redirect_uri', $selectedRedirect)
+        }
+    } elseif (-not [string]::IsNullOrWhiteSpace($RedirectUrl)) {
+        # An explicit redirect override must stay consistent throughout the flow.
+        $query.Set('redirect_uri', $RedirectUrl)
+    }
+    foreach ($requiredParameter in @('client_id', 'response_type', 'redirect_uri')) {
+        if ([string]::IsNullOrWhiteSpace($query.Get($requiredParameter))) {
+            throw "Missing required parameter '$requiredParameter' in auth URL."
+        }
+    }
+    if (-not $query.Get('sso_reload')) { $query.Set('sso_reload', 'true') }
+    if ($Username -and -not $query.Get('login_hint')) { $query.Set('login_hint', $Username) }
+    if ($UseCodeVerifier) {
+        $query.Set('code_challenge', (Get-TTCodeChallenge -CodeVerifier $CodeVerifier))
+        $query.Set('code_challenge_method', 'S256')
+    }
+    if ($UseCAE -and -not $resolved.UseV1Endpoint) {
+        $claims = @{ access_token = @{ xms_cc = @{ values = @('cp1') } } } | ConvertTo-Json -Compress -Depth 10
+        $query.Set('claims', $claims)
+    }
+
+    $builder.Query = $query.ToString()
+    $actualRedirect = $query.Get('redirect_uri')
+    $actualClientId = $query.Get('client_id')
+    $actualScope = $query.Get('scope')
+    $actualResource = $query.Get('resource')
+
+    [PSCustomObject]@{
+        Url                    = $builder.Uri.AbsoluteUri
+        Client                 = $resolved.Client
+        ClientID               = $actualClientId
+        Tenant                 = $Tenant
+        Authority              = $Authority
+        RedirectUrl            = $actualRedirect
+        Scope                  = $actualScope
+        Resource               = $actualResource
+        UseV1Endpoint          = [bool]$resolved.UseV1Endpoint
+        UseCAE                 = $UseCAE.IsPresent
+        UseCodeVerifier        = $UseCodeVerifier.IsPresent
+        CodeVerifier           = $CodeVerifier
+        AuthorizationCodeState = $query.Get('state')
+    }
+}

--- a/modules/New-EntraIDUserHandle.ps1
+++ b/modules/New-EntraIDUserHandle.ps1
@@ -65,14 +65,17 @@ function New-EntraIDUserHandle {
     [System.Buffer]::BlockCopy($tenantBytes, 0, $userHandleBytes, $onBytes.Length, $tenantBytes.Length)
     [System.Buffer]::BlockCopy($userHashBytes, 0, $userHandleBytes, ($onBytes.Length + $tenantBytes.Length), $userHashBytes.Length)
 
-    # 6. Encode the final output (Base64 is standard for JSON/Auth tokens, Hex provided as backup)
+    # 6. Encode the final output. WebAuthn assertion fields use unpadded Base64URL.
     $userHandleBase64 = [Convert]::ToBase64String($userHandleBytes)
+    $userHandleBase64Url = $userHandleBase64.Replace('+', '-').Replace('/', '_').TrimEnd('=')
     $userHandleHex = [System.BitConverter]::ToString($userHandleBytes).Replace("-", "").ToLower()
 
     # Output the results
     [PSCustomObject]@{
         TenantId         = $TenantId
         UserId           = $UserId
+        UserHandle       = $userHandleBase64Url
+        UserHandleBase64Url = $userHandleBase64Url
         UserHandleBase64 = $userHandleBase64
         UserHandleHex    = $userHandleHex
     }

--- a/modules/New-EntraIDUserHandle.ps1
+++ b/modules/New-EntraIDUserHandle.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Generates the FIDO2 user handle for an Entra ID user.
+
+.DESCRIPTION
+    Calculates the user handle used in FIDO2/WebAuthn assertions for Entra ID from the
+    tenant ID and the user's object ID. The handle is constructed as the byte sequence
+    "ON:" + tenant ID (little-endian) + SHA256(user ID little-endian).
+
+    This is a public helper, e.g. to determine the userHandle value required by
+    Invoke-EntraIDPasskeyLogin when using a software-based passkey.
+
+.PARAMETER TenantId
+    The Entra ID tenant ID (GUID).
+
+.PARAMETER UserId
+    The Entra ID object ID (GUID) of the user.
+
+.EXAMPLE
+    New-EntraIDUserHandle -TenantId "00000000-0000-0000-0000-000000000001" -UserId "00000000-0000-0000-0000-000000000002"
+    Returns the user handle as Base64 and hex encoded strings.
+
+.NOTES
+    Part of TokenTacticsV2
+    https://github.com/f-bader/TokenTacticsV2
+
+    Based on Generate-UserHandle: https://gist.github.com/f-bader/501aaeb9a79f58359e0a5c2892763a52
+#>
+function New-EntraIDUserHandle {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$TenantId,
+
+        [Parameter(Mandatory = $true)]
+        [string]$UserId
+    )
+
+    # 1. Parse the strings into GUID objects
+    try {
+        $tenantGuid = [guid]::Parse($TenantId)
+        $userGuid = [guid]::Parse($UserId)
+    } catch {
+        throw "TenantId and UserId must be valid GUIDs. $($_.Exception.Message)"
+    }
+
+    # 2. Get the "ON:" static string as a byte array (ASCII)
+    $onBytes = [System.Text.Encoding]::ASCII.GetBytes("ON:")
+
+    # 3. Get Tenant ID in little-endian binary presentation
+    # (.NET natively exports the first 3 components of a GUID as little-endian)
+    $tenantBytes = $tenantGuid.ToByteArray()
+
+    # 4. Get User ID in the same binary presentation and calculate its SHA256 Hash
+    $userBytes = $userGuid.ToByteArray()
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    $userHashBytes = $sha256.ComputeHash($userBytes)
+    $sha256.Dispose()
+
+    # 5. Concatenate the three byte arrays: [ "ON:" + TenantBytes + UserHashBytes ]
+    $totalLength = $onBytes.Length + $tenantBytes.Length + $userHashBytes.Length
+    $userHandleBytes = [byte[]]::new($totalLength)
+
+    [System.Buffer]::BlockCopy($onBytes, 0, $userHandleBytes, 0, $onBytes.Length)
+    [System.Buffer]::BlockCopy($tenantBytes, 0, $userHandleBytes, $onBytes.Length, $tenantBytes.Length)
+    [System.Buffer]::BlockCopy($userHashBytes, 0, $userHandleBytes, ($onBytes.Length + $tenantBytes.Length), $userHashBytes.Length)
+
+    # 6. Encode the final output (Base64 is standard for JSON/Auth tokens, Hex provided as backup)
+    $userHandleBase64 = [Convert]::ToBase64String($userHandleBytes)
+    $userHandleHex = [System.BitConverter]::ToString($userHandleBytes).Replace("-", "").ToLower()
+
+    # Output the results
+    [PSCustomObject]@{
+        TenantId         = $TenantId
+        UserId           = $UserId
+        UserHandleBase64 = $userHandleBase64
+        UserHandleHex    = $userHandleHex
+    }
+}

--- a/tests/Fido2SplitFlow.Tests.ps1
+++ b/tests/Fido2SplitFlow.Tests.ps1
@@ -1,0 +1,256 @@
+BeforeAll {
+    . "$PSScriptRoot/fixtures/TestData.ps1"
+    Import-Module $script:ModulePath -Force
+
+    $script:SessionInformation = [PSCustomObject]@{
+        sFidoChallenge     = 'server-challenge-value'
+        sFT                = 'flow-token'
+        sCtx               = 'context'
+        canary             = 'canary'
+        correlationId      = 'correlation'
+        urlPost            = '/post'
+        urlPostAad         = '/post-aad'
+        urlPostMsa         = '/post-msa'
+        urlRefresh         = '/refresh'
+        urlResume          = '/resume'
+        UserPrincipalName  = 'user@contoso.com'
+        RelyingParty       = 'login.microsoft.com'
+        Origin             = 'https://login.microsoft.com'
+        oGetCredTypeResult = [PSCustomObject]@{
+            FlowToken   = 'credential-flow-token'
+            Credentials = [PSCustomObject]@{
+                HasFido    = $true
+                FidoParams = [PSCustomObject]@{ AllowList = @('credential') }
+            }
+        }
+    }
+
+    $script:ResponseInformation = @{
+        sCrossDomainCanary = 'cross-domain-canary'
+        sessionId          = 'session-id'
+        sCtx               = 'response-context'
+        canary             = 'response-canary'
+        sFT                = 'response-flow-token'
+    } | ConvertTo-Json -Compress
+
+    $script:Assertion = [PSCustomObject]@{
+        id                = 'credential-id'
+        clientDataJSON    = 'Y2xpZW50RGF0YQ'
+        authenticatorData = 'YXV0aGVudGljYXRvckRhdGE'
+        signature         = 'c2lnbmF0dXJl'
+        userHandle        = 'dXNlckhhbmRsZQ'
+    }
+
+    $script:EstsCookieValue = '0.fake-ests-cookie-value-with-enough-length'
+}
+
+AfterAll {
+    Remove-Variable -Scope Global -Name Fido2WebSession, ESTSAUTH, webSession, response -ErrorAction SilentlyContinue
+}
+
+Describe 'New-EntraIDUserHandle' {
+    It 'calculates the expected user handle for a known tenant and user id' {
+        $result = New-EntraIDUserHandle -TenantId '00112233-4455-6677-8899-aabbccddeeff' -UserId 'ffeeddcc-bbaa-9988-7766-554433221100'
+
+        $result.TenantId | Should -Be '00112233-4455-6677-8899-aabbccddeeff'
+        $result.UserId | Should -Be 'ffeeddcc-bbaa-9988-7766-554433221100'
+        $result.UserHandleBase64 | Should -Be 'T046MyIRAFVEd2aImaq7zN3u/+XL2v8mea6v5bMB3Jw5+rS+TeKZ6lehLC8UuwzR6I2C'
+        $result.UserHandleHex | Should -Be '4f4e3a33221100554477668899aabbccddeeffe5cbdaff2679aeafe5b301dc9c39fab4be4de299ea57a12c2f14bb0cd1e88d82'
+    }
+
+    It 'throws when a GUID cannot be parsed' {
+        { New-EntraIDUserHandle -TenantId 'not-a-guid' -UserId 'ffeeddcc-bbaa-9988-7766-554433221100' } | Should -Throw '*valid GUIDs*'
+    }
+}
+
+Describe 'Get-EntraIDFido2Challenge' {
+    BeforeEach {
+        $script:CapturedUri = $null
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            param($Uri)
+            $script:CapturedUri = $Uri
+            return [PSCustomObject]@{ Content = ($script:SessionInformation | ConvertTo-Json -Compress -Depth 10); StatusCode = 200 }
+        }
+    }
+
+    AfterEach {
+        Remove-Variable -Scope Global -Name Fido2WebSession -ErrorAction SilentlyContinue
+    }
+
+    It 'returns only the challenge string and saves the session state in a global variable' {
+        $result = Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com'
+
+        $result | Should -Be 'server-challenge-value'
+
+        $global:Fido2WebSession | Should -Not -BeNullOrEmpty
+        $global:Fido2WebSession.Fido2SessionInfo | Should -Not -BeNullOrEmpty
+        $global:Fido2WebSession.Fido2SessionInfo.UserPrincipalName | Should -Be 'user@contoso.com'
+        $global:Fido2WebSession.Fido2SessionInfo.sFidoChallenge | Should -Be 'server-challenge-value'
+    }
+
+    It 'adds sso_reload and login_hint to the authorize request' {
+        Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com'
+
+        $script:CapturedUri | Should -Match 'sso_reload=true'
+        $script:CapturedUri | Should -Match 'login_hint=user@contoso\.com'
+    }
+
+    It 'throws when the user has no FIDO credentials registered' {
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            $noFido = [PSCustomObject]@{
+                oGetCredTypeResult = [PSCustomObject]@{
+                    Credentials = [PSCustomObject]@{ HasFido = $false }
+                }
+            }
+            return [PSCustomObject]@{ Content = ($noFido | ConvertTo-Json -Compress -Depth 10); StatusCode = 200 }
+        }
+
+        { Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com' } | Should -Throw '*FIDO*'
+    }
+
+    It 'throws when the auth URL is not a login.microsoftonline.com URL' {
+        { Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com' -AuthUrl 'https://example.com/authorize?client_id=x&response_type=code&redirect_uri=y' } | Should -Throw "*must start with 'https://login.microsoftonline.com/'*"
+    }
+}
+
+Describe 'ConvertFrom-TTUserSid' {
+    It 'converts an Entra ID user SID to the correct object ID' {
+        $result = InModuleScope TokenTactics {
+            ConvertFrom-TTUserSid -Sid 'S-1-12-1-223508383-1125077638-3128705954-3034186293'
+        }
+
+        $result | Should -Be ([guid]'0d52779f-5286-430f-a243-7cba3502dab4')
+    }
+
+    It 'throws for a SID that is not an Entra ID user SID' {
+        { InModuleScope TokenTactics { ConvertFrom-TTUserSid -Sid 'S-1-5-21-123456789-123456789-123456789-1001' } } | Should -Throw '*not a valid Entra ID user SID*'
+    }
+}
+
+Describe 'Get-WindowsHelloFidoAssertion parameter validation' {
+    It 'rejects a UserId that is not a GUID' {
+        { Get-WindowsHelloFidoAssertion -Challenge 'challenge' -UserId 'katie.summer@contoso.com' } | Should -Throw '*object ID (GUID)*'
+    }
+}
+
+Describe 'Get-WindowsHelloFidoAssertion platform guard' -Skip:($IsWindows) {
+    It 'throws on non-Windows platforms' {
+        { Get-WindowsHelloFidoAssertion -Challenge 'challenge' -UserId 'ffeeddcc-bbaa-9988-7766-554433221100' } | Should -Throw '*supported only on Windows*'
+    }
+
+    It 'throws on non-Windows platforms when UserId is omitted' {
+        { Get-WindowsHelloFidoAssertion -Challenge 'challenge' } | Should -Throw '*supported only on Windows*'
+    }
+}
+
+Describe 'Invoke-EntraIDPasskeyAssertionLogin' {
+    BeforeEach {
+        $script:Session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+        $cookie = [System.Net.Cookie]::new('ESTSAUTH', $script:EstsCookieValue)
+        $script:Session.Cookies.Add('https://login.microsoftonline.com/', $cookie)
+        Add-Member -InputObject $script:Session -NotePropertyName 'Fido2SessionInfo' -NotePropertyValue $script:SessionInformation -Force
+
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            param($Uri)
+            if ($Uri -eq 'https://login.microsoft.com/common/fido/get?uiflavor=Web') {
+                return [PSCustomObject]@{ Content = $script:ResponseInformation; StatusCode = 200 }
+            }
+            return [PSCustomObject]@{ Content = '{}'; StatusCode = 200; Error = $null }
+        }
+        Mock -ModuleName TokenTactics Get-EntraIDTokenFromESTSCookie { }
+    }
+
+    AfterEach {
+        Remove-Variable -Scope Global -Name Fido2WebSession, ESTSAUTH, webSession, response -ErrorAction SilentlyContinue
+    }
+
+    It 'submits the assertion to the login endpoint using the saved global web session' {
+        $global:Fido2WebSession = $script:Session
+
+        Invoke-EntraIDPasskeyAssertionLogin -Assertion $script:Assertion
+
+        Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1 -Exactly -Scope It -ParameterFilter {
+            if ($Uri -ne 'https://login.microsoftonline.com/common/login') {
+                return $false
+            }
+            $assertion = $Body.assertion | ConvertFrom-Json
+            $assertion.id -eq 'credential-id' -and
+            $assertion.userHandle -eq 'dXNlckhhbmRsZQ' -and
+            $Body.lmcCanary -eq 'cross-domain-canary' -and
+            $Body.hpgrequestid -eq 'session-id'
+        }
+        Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1 -Exactly -Scope It -ParameterFilter {
+            $Uri -eq 'https://login.microsoftonline.com/common/login?sso_reload=true' -and
+            $Body.ctx -eq 'context' -and
+            $Body.canary -eq 'canary' -and
+            $Body.flowToken -eq 'credential-flow-token'
+        }
+    }
+
+    It 'accepts the assertion as a JSON string and uses the session username for the verify request' {
+        Invoke-EntraIDPasskeyAssertionLogin -Assertion ($script:Assertion | ConvertTo-Json -Compress) -WebSession $script:Session -SessionInfo $script:SessionInformation
+
+        Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1 -Exactly -Scope It -ParameterFilter {
+            $Uri -eq 'https://login.microsoft.com/common/fido/get?uiflavor=Web' -and
+            $Body.username -eq 'user@contoso.com' -and
+            $Body.credentialsJson -eq 'credential'
+        }
+    }
+
+    It 'returns the ESTSAUTH cookie value when OutputType is ESTSAUTHCookie' {
+        $result = Invoke-EntraIDPasskeyAssertionLogin -Assertion $script:Assertion -WebSession $script:Session -SessionInfo $script:SessionInformation -OutputType ESTSAUTHCookie
+
+        $result | Should -Be $script:EstsCookieValue
+        $global:ESTSAUTH | Should -Be $script:EstsCookieValue
+        $global:webSession | Should -Be $script:Session
+        Should -Invoke -ModuleName TokenTactics Get-EntraIDTokenFromESTSCookie -Times 0 -Exactly -Scope It
+    }
+
+    It 'exchanges the ESTSAUTH cookie for tokens by default' {
+        Invoke-EntraIDPasskeyAssertionLogin -Assertion $script:Assertion -WebSession $script:Session -SessionInfo $script:SessionInformation
+
+        Should -Invoke -ModuleName TokenTactics Get-EntraIDTokenFromESTSCookie -Times 1 -Exactly -Scope It -ParameterFilter {
+            $CookieValue -eq $script:EstsCookieValue -and
+            $ESTSCookieType -eq 'ESTSAUTH' -and
+            $Client -eq 'MSTeams'
+        }
+    }
+
+    It 'tolerates the expected redirect error when the assertion is accepted' -ForEach @(
+        'Operation is not valid due to the current state of the object.'
+        'The maximum redirection count has been exceeded. To increase the number of redirections allowed, supply a higher value to the -MaximumRedirection parameter.'
+    ) {
+        $script:RedirectMessage = $_
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            param($Uri)
+            if ($Uri -eq 'https://login.microsoft.com/common/fido/get?uiflavor=Web') {
+                return [PSCustomObject]@{ Content = $script:ResponseInformation; StatusCode = 200 }
+            }
+            if ($Uri -like 'https://login.microsoftonline.com/common/login*') {
+                throw $script:RedirectMessage
+            }
+            return [PSCustomObject]@{ Content = '{}'; StatusCode = 200; Error = $null }
+        }
+
+        Invoke-EntraIDPasskeyAssertionLogin -Assertion $script:Assertion -WebSession $script:Session -SessionInfo $script:SessionInformation
+
+        Should -Invoke -ModuleName TokenTactics Get-EntraIDTokenFromESTSCookie -Times 1 -Exactly -Scope It
+    }
+
+    It 'throws when the assertion is missing a required property' {
+        $broken = [PSCustomObject]@{
+            id                = 'credential-id'
+            clientDataJSON    = 'Y2xpZW50RGF0YQ'
+            authenticatorData = 'YXV0aGVudGljYXRvckRhdGE'
+            signature         = 'c2lnbmF0dXJl'
+        }
+
+        { Invoke-EntraIDPasskeyAssertionLogin -Assertion $broken -WebSession $script:Session -SessionInfo $script:SessionInformation } | Should -Throw "*missing required property 'userHandle'*"
+    }
+
+    It 'throws when no web session is available' {
+        Remove-Variable -Scope Global -Name Fido2WebSession -ErrorAction SilentlyContinue
+
+        { Invoke-EntraIDPasskeyAssertionLogin -Assertion $script:Assertion } | Should -Throw '*Get-EntraIDFido2Challenge*'
+    }
+}

--- a/tests/Fido2SplitFlow.Tests.ps1
+++ b/tests/Fido2SplitFlow.Tests.ps1
@@ -45,7 +45,7 @@ BeforeAll {
 }
 
 AfterAll {
-    Remove-Variable -Scope Global -Name Fido2WebSession, ESTSAUTH, webSession, response -ErrorAction SilentlyContinue
+    Remove-Variable -Scope Global -Name Fido2WebSession, Fido2FlowState, ESTSAUTH, webSession, response -ErrorAction SilentlyContinue
 }
 
 Describe 'New-EntraIDUserHandle' {
@@ -55,6 +55,8 @@ Describe 'New-EntraIDUserHandle' {
         $result.TenantId | Should -Be '00112233-4455-6677-8899-aabbccddeeff'
         $result.UserId | Should -Be 'ffeeddcc-bbaa-9988-7766-554433221100'
         $result.UserHandleBase64 | Should -Be 'T046MyIRAFVEd2aImaq7zN3u/+XL2v8mea6v5bMB3Jw5+rS+TeKZ6lehLC8UuwzR6I2C'
+        $result.UserHandleBase64Url | Should -Be 'T046MyIRAFVEd2aImaq7zN3u_-XL2v8mea6v5bMB3Jw5-rS-TeKZ6lehLC8UuwzR6I2C'
+        $result.UserHandle | Should -Be $result.UserHandleBase64Url
         $result.UserHandleHex | Should -Be '4f4e3a33221100554477668899aabbccddeeffe5cbdaff2679aeafe5b301dc9c39fab4be4de299ea57a12c2f14bb0cd1e88d82'
     }
 
@@ -74,15 +76,20 @@ Describe 'Get-EntraIDFido2Challenge' {
     }
 
     AfterEach {
-        Remove-Variable -Scope Global -Name Fido2WebSession -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name Fido2WebSession, Fido2FlowState -ErrorAction SilentlyContinue
     }
 
-    It 'returns only the challenge string and saves the session state in a global variable' {
+    It 'returns structured flow state and saves the session state in global variables' {
         $result = Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com'
 
-        $result | Should -Be 'server-challenge-value'
+        $result.Challenge | Should -Be 'server-challenge-value'
+        $result.OAuth.Client | Should -Be 'MSGraph'
+        $result.OAuth.ClientID | Should -Be 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        $result.OAuth.RedirectUrl | Should -Be 'ms-appx-web://Microsoft.AAD.BrokerPlugIn/S-1-15-2-1479478596-3248452454-924133441-2206841801-2812823084-3237817612-3652912309'
+        $result.PostbackUrl | Should -Be '/post'
 
         $global:Fido2WebSession | Should -Not -BeNullOrEmpty
+        $global:Fido2FlowState | Should -Not -BeNullOrEmpty
         $global:Fido2WebSession.Fido2SessionInfo | Should -Not -BeNullOrEmpty
         $global:Fido2WebSession.Fido2SessionInfo.UserPrincipalName | Should -Be 'user@contoso.com'
         $global:Fido2WebSession.Fido2SessionInfo.sFidoChallenge | Should -Be 'server-challenge-value'
@@ -92,7 +99,22 @@ Describe 'Get-EntraIDFido2Challenge' {
         Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com'
 
         $script:CapturedUri | Should -Match 'sso_reload=true'
-        $script:CapturedUri | Should -Match 'login_hint=user@contoso\.com'
+        $script:CapturedUri | Should -Match 'login_hint=user%40contoso\.com'
+    }
+
+    It 'parses an authorize response with a JavaScript config assignment and trailing semicolon' {
+        Mock -ModuleName TokenTactics Invoke-WebRequest {
+            $config = $script:SessionInformation | ConvertTo-Json -Compress -Depth 10
+            return [PSCustomObject]@{
+                Content = "<script>`$Config = $config;</script>"
+                StatusCode = 200
+            }
+        }
+
+        $result = Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com' -Client Outlook
+
+        $result.Challenge | Should -Be 'server-challenge-value'
+        $result.PostbackUrl | Should -Be '/post'
     }
 
     It 'throws when the user has no FIDO credentials registered' {
@@ -109,7 +131,44 @@ Describe 'Get-EntraIDFido2Challenge' {
     }
 
     It 'throws when the auth URL is not a login.microsoftonline.com URL' {
-        { Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com' -AuthUrl 'https://example.com/authorize?client_id=x&response_type=code&redirect_uri=y' } | Should -Throw "*must start with 'https://login.microsoftonline.com/'*"
+        { Get-EntraIDFido2Challenge -UserPrincipalName 'user@contoso.com' -AuthUrl 'https://example.com/authorize?client_id=x&response_type=code&redirect_uri=y' } | Should -Throw '*login.microsoftonline.com*'
+    }
+
+    It 'builds OAuth URLs from the refresh-token client aliases and supports PKCE' {
+        $result = Get-EntraIDFido2Challenge `
+            -UserPrincipalName 'user@contoso.com' `
+            -Client AzureManagement `
+            -Tenant 'contoso.onmicrosoft.com' `
+            -RedirectUrl 'https://app.example/callback' `
+            -UseCodeVerifier `
+            -CodeVerifier 'fixed-verifier'
+
+        $result.OAuth.Client | Should -Be 'AzureManagement'
+        $result.OAuth.ClientID | Should -Be 'd3590ed6-52b3-4102-aeff-aad2292ab01c'
+        $result.OAuth.CodeVerifier | Should -Be 'fixed-verifier'
+        $result.OAuth.RedirectUrl | Should -Be 'https://app.example/callback'
+        $script:CapturedUri | Should -Match 'organizations|contoso\.onmicrosoft\.com'
+        $script:CapturedUri | Should -Match 'code_challenge_method=S256'
+        $script:CapturedUri | Should -Match 'redirect_uri=https%3a%2f%2fapp.example%2fcallback'
+    }
+
+    It 'selects the registered redirect URI from the effective client ID' {
+        $oauth = InModuleScope TokenTactics {
+            New-TTEntraAuthorizationUrl `
+                -Client Custom `
+                -ClientID '9ba1a5c7-f17a-4de9-a1f1-6178c8d51223' `
+                -Scope 'openid'
+        }
+
+        $oauth.RedirectUrl | Should -Be 'ms-appx-web://Microsoft.AAD.BrokerPlugin/9ba1a5c7-f17a-4de9-a1f1-6178c8d51223'
+    }
+
+    It 'requires an explicit redirect URI for an unknown client ID' {
+        {
+            InModuleScope TokenTactics {
+                New-TTEntraAuthorizationUrl -Client Custom -ClientID '00000000-0000-0000-0000-000000000001' -Scope 'openid'
+            }
+        } | Should -Throw '*Provide -RedirectUrl*'
     }
 }
 
@@ -170,7 +229,7 @@ Describe 'Invoke-EntraIDPasskeyAssertionLogin' {
         Invoke-EntraIDPasskeyAssertionLogin -Assertion $script:Assertion
 
         Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1 -Exactly -Scope It -ParameterFilter {
-            if ($Uri -ne 'https://login.microsoftonline.com/common/login') {
+            if ($Uri -ne 'https://login.microsoftonline.com/post') {
                 return $false
             }
             $assertion = $Body.assertion | ConvertFrom-Json
@@ -180,7 +239,7 @@ Describe 'Invoke-EntraIDPasskeyAssertionLogin' {
             $Body.hpgrequestid -eq 'session-id'
         }
         Should -Invoke -ModuleName TokenTactics Invoke-WebRequest -Times 1 -Exactly -Scope It -ParameterFilter {
-            $Uri -eq 'https://login.microsoftonline.com/common/login?sso_reload=true' -and
+            $Uri -eq 'https://login.microsoftonline.com/post?sso_reload=true' -and
             $Body.ctx -eq 'context' -and
             $Body.canary -eq 'canary' -and
             $Body.flowToken -eq 'credential-flow-token'
@@ -212,7 +271,9 @@ Describe 'Invoke-EntraIDPasskeyAssertionLogin' {
         Should -Invoke -ModuleName TokenTactics Get-EntraIDTokenFromESTSCookie -Times 1 -Exactly -Scope It -ParameterFilter {
             $CookieValue -eq $script:EstsCookieValue -and
             $ESTSCookieType -eq 'ESTSAUTH' -and
-            $Client -eq 'MSTeams'
+            $Client -eq 'Custom' -and
+            $ClientID -eq 'd3590ed6-52b3-4102-aeff-aad2292ab01c' -and
+            $Scope -eq 'https://graph.microsoft.com/.default offline_access openid'
         }
     }
 
@@ -226,7 +287,7 @@ Describe 'Invoke-EntraIDPasskeyAssertionLogin' {
             if ($Uri -eq 'https://login.microsoft.com/common/fido/get?uiflavor=Web') {
                 return [PSCustomObject]@{ Content = $script:ResponseInformation; StatusCode = 200 }
             }
-            if ($Uri -like 'https://login.microsoftonline.com/common/login*') {
+            if ($Uri -like 'https://login.microsoftonline.com/post*') {
                 throw $script:RedirectMessage
             }
             return [PSCustomObject]@{ Content = '{}'; StatusCode = 200; Error = $null }
@@ -249,7 +310,7 @@ Describe 'Invoke-EntraIDPasskeyAssertionLogin' {
     }
 
     It 'throws when no web session is available' {
-        Remove-Variable -Scope Global -Name Fido2WebSession -ErrorAction SilentlyContinue
+        Remove-Variable -Scope Global -Name Fido2WebSession, Fido2FlowState -ErrorAction SilentlyContinue
 
         { Invoke-EntraIDPasskeyAssertionLogin -Assertion $script:Assertion } | Should -Throw '*Get-EntraIDFido2Challenge*'
     }

--- a/tests/Module.Tests.ps1
+++ b/tests/Module.Tests.ps1
@@ -7,6 +7,7 @@ BeforeAll {
         'ConvertFrom-JWTtoken'
         'ConvertTo-PEMPrivateKey'
         'Get-EntraIDAuthorizationCode'
+        'Get-EntraIDFido2Challenge'
         'Get-EntraIDTokenFromCertificate'
         'Get-EntraIDTokenFromDeviceCode'
         'Get-EntraIDTokenFromAuthorizationCode'
@@ -17,6 +18,8 @@ BeforeAll {
         'Get-EntraIDTokenFromSCCAUTHCookie'
         'Get-ForgedUserAgent'
         'Get-TenantID'
+        'Get-WindowsHelloFidoAssertion'
+        'Invoke-EntraIDPasskeyAssertionLogin'
         'Invoke-EntraIDPasskeyLogin'
         'Invoke-RefreshToAzureCoreManagementToken'
         'Invoke-RefreshToAzureKeyVaultToken'
@@ -36,6 +39,7 @@ BeforeAll {
         'Invoke-RefreshToSharePointToken'
         'Invoke-RefreshToSubstrateToken'
         'Invoke-RefreshToYammerToken'
+        'New-EntraIDUserHandle'
         'New-TPMCertificate'
     )
 


### PR DESCRIPTION
## Summary

- Add Get-EntraIDFido2Challenge to retrieve the FIDO2 challenge and retain the session for completion.
- Add Get-WindowsHelloFidoAssertion, based on Dirk-jan Mollema ROADtools code and released under MIT, with NCrypt Windows Hello signing and compressed JSON output.
- Add New-EntraIDUserHandle as a public helper.
- Add Invoke-EntraIDPasskeyAssertionLogin with token and ESTSAUTHCookie output modes.
- Handle expected redirect responses across platforms and preserve real finalization errors.
- Update exports, README, module version to 0.4.0, and add split-flow tests.

## Testing

- pwsh -NoProfile -File ./tests/Invoke-Tests.ps1
- 214 passed, 0 failed, 4 skipped
- Coverage: 64.07% (60% baseline)
